### PR TITLE
feat: presentation 画面からの操作とポインターツール (レーザー/ペン)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-presentation-controls-and-pointer-tools.md
+++ b/docs/superpowers/plans/2026-04-24-presentation-controls-and-pointer-tools.md
@@ -1,0 +1,1618 @@
+# Presentation 画面操作とポインターツール Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** presentation 画面からもページ送りが可能なバックアップ操作と、両画面で双方向同期するレーザー/ペンのポインターツールを導入する。
+
+**Architecture:** 既存の Jotai + BroadcastChannel アーキテクチャを維持。ナビゲーション解決ロジックは既存 `src/lib/navigation-utils.ts` を拡張。ポインター/ペンは両画面に SVG オーバーレイを重ね、双方向同期コマンドで state を揃える。送信側は local state を即更新しつつ broadcast する（自己エコー不要）。
+
+**Tech Stack:** React 19, Jotai, TanStack Router, TypeScript (strict), BroadcastChannel API, vitest, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md`
+
+---
+
+## ファイル構造
+
+**新規**:
+- `src/lib/navigation-utils.test.ts` — vitest 初導入、既存 + 追加ヘルパーのテスト
+- `src/lib/pointer-state.ts` — ツールモード/レーザー位置/ペンストロークの atom
+- `src/lib/pointer-state.test.ts` — 純粋 state ロジックのテスト
+- `src/components/PointerOverlay.tsx` — SVG オーバーレイ
+- `src/broadcast/tools.ts` — ツール系 broadcast 型宣言 + 送信 helper
+- `src/routes/-hooks/use-tool-shortcut.ts` — `L`/`D`/`E`/`Esc` 共通ショートカット
+- `src/routes/presentation/-hooks/use-presentation-shortcut.ts` — presentation 側ナビゲーションショートカット
+
+**修正**:
+- `src/lib/navigation-utils.ts` — `resolveNextPage`/`resolvePrevPage`/`resolveFirstSlide`/`resolveLastSlide` を追加
+- `src/broadcast/presenter.ts` — `navigate` とツール系コマンドの受信処理、ツール系の send helper
+- `src/broadcast/presentation.ts` — ツール系コマンドの受信、`navigate` 送信 helper
+- `src/broadcast/index.ts` — 新 hooks の re-export
+- `src/routes/(main)/presenter.tsx` — ナビゲーションを helper で書き換え、overlay/ツールフック統合、ページ遷移時の pen クリア
+- `src/routes/presentation/index.tsx` — `use-presentation-shortcut` / `use-tool-shortcut` / `PointerOverlay` 統合
+- `src/routes/presentation/-Menu.tsx` — toolMode 中のメニュー自動表示抑制
+
+---
+
+## Task 1: ナビゲーションヘルパー拡張 + テスト導入
+
+**Files:**
+- Test: `src/lib/navigation-utils.test.ts` (create)
+- Modify: `src/lib/navigation-utils.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/lib/navigation-utils.test.ts` を作成:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { ResolvedPdfpcConfigV2 } from "./pdfpc-config.ts";
+import {
+	clampPageNumber,
+	getNextUserSlidePageNumber,
+	getPrevUserSlidePageNumber,
+	resolveFirstSlide,
+	resolveLastSlide,
+	resolveNextPage,
+	resolvePrevPage,
+} from "./navigation-utils.ts";
+
+const makeConfig = (
+	pages: number[][],
+): Pick<ResolvedPdfpcConfigV2, "pages" | "totalOverlays"> => ({
+	pages: pages.map((group) =>
+		group.map((pageNumber) => ({
+			pageNumber,
+			label: String(pageNumber),
+			hidden: false,
+			note: "",
+		})),
+	) as ResolvedPdfpcConfigV2["pages"],
+	totalOverlays: pages.flat().length,
+});
+
+describe("clampPageNumber", () => {
+	it("最小1", () => expect(clampPageNumber(0, 10)).toBe(1));
+	it("最大 max", () => expect(clampPageNumber(99, 10)).toBe(10));
+	it("範囲内はそのまま", () => expect(clampPageNumber(5, 10)).toBe(5));
+});
+
+describe("resolveNextPage", () => {
+	it("通常は +1", () => expect(resolveNextPage(5, 10)).toBe(6));
+	it("末尾では同値", () => expect(resolveNextPage(10, 10)).toBe(10));
+});
+
+describe("resolvePrevPage", () => {
+	it("通常は -1", () => expect(resolvePrevPage(5, 10)).toBe(4));
+	it("先頭では 1", () => expect(resolvePrevPage(1, 10)).toBe(1));
+});
+
+describe("resolveFirstSlide / resolveLastSlide", () => {
+	it("first は 1", () => expect(resolveFirstSlide()).toBe(1));
+	it("last は totalOverlays", () => expect(resolveLastSlide(10)).toBe(10));
+});
+
+describe("getNextUserSlidePageNumber", () => {
+	const { pages } = makeConfig([[1, 2], [3], [4, 5, 6]]);
+	it("グループ内から次グループ先頭へ", () =>
+		expect(getNextUserSlidePageNumber(pages, 1)).toBe(3));
+	it("中央からでも次グループ先頭へ", () =>
+		expect(getNextUserSlidePageNumber(pages, 2)).toBe(3));
+	it("最後のグループでは null", () =>
+		expect(getNextUserSlidePageNumber(pages, 5)).toBe(null));
+});
+
+describe("getPrevUserSlidePageNumber", () => {
+	const { pages } = makeConfig([[1, 2], [3], [4, 5, 6]]);
+	it("グループ内から前グループ先頭へ", () =>
+		expect(getPrevUserSlidePageNumber(pages, 5)).toBe(3));
+	it("最初のグループでは null", () =>
+		expect(getPrevUserSlidePageNumber(pages, 1)).toBe(null));
+});
+```
+
+- [ ] **Step 2: テスト実行して失敗を確認**
+
+Run: `pnpm test src/lib/navigation-utils.test.ts`
+Expected: FAIL — `resolveNextPage`, `resolvePrevPage`, `resolveFirstSlide`, `resolveLastSlide` は未定義
+
+- [ ] **Step 3: 実装を追加**
+
+`src/lib/navigation-utils.ts` 末尾に追加:
+
+```ts
+/**
+ * 次のページ番号を解決する（単純 +1、末尾クランプ）
+ */
+export function resolveNextPage(
+	currentPageNumber: number,
+	totalOverlays: number,
+): number {
+	return clampPageNumber(currentPageNumber + 1, totalOverlays);
+}
+
+/**
+ * 前のページ番号を解決する（単純 -1、先頭クランプ）
+ */
+export function resolvePrevPage(
+	currentPageNumber: number,
+	totalOverlays: number,
+): number {
+	return clampPageNumber(currentPageNumber - 1, totalOverlays);
+}
+
+/**
+ * 最初のページ番号
+ */
+export function resolveFirstSlide(): number {
+	return 1;
+}
+
+/**
+ * 最後のページ番号
+ */
+export function resolveLastSlide(totalOverlays: number): number {
+	return totalOverlays;
+}
+```
+
+- [ ] **Step 4: テスト成功確認**
+
+Run: `pnpm test src/lib/navigation-utils.test.ts`
+Expected: PASS (全ケース緑)
+
+- [ ] **Step 5: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/navigation-utils.ts src/lib/navigation-utils.test.ts
+git commit -m "feat(navigation): resolveNext/Prev/First/Last ヘルパーとテストを追加"
+```
+
+---
+
+## Task 2: 双方向 `navigate` コマンドの broadcast 定義
+
+**Files:**
+- Modify: `src/broadcast/presentation.ts`
+- Modify: `src/broadcast/presenter.ts`
+
+- [ ] **Step 1: presentation → presenter の `navigate` コマンドを定義**
+
+`src/broadcast/presenter.ts` の `declare global` 内に追加:
+
+```ts
+declare global {
+	interface PresentationCommandMap {
+		initialize: EmptyObject;
+		"get-config": EmptyObject;
+		"get-pdf": EmptyObject;
+		"get-blackout-state": EmptyObject;
+		"get-current-page-number": EmptyObject;
+		navigate: {
+			direction: "next" | "prev" | "home" | "end";
+		};
+	}
+}
+```
+
+- [ ] **Step 2: presenter 側に `navigate` 受信ハンドラを追加（まだ呼び出されない状態でよい）**
+
+`src/broadcast/presenter.ts` の `usePresenterBroadcast` の引数に `onNavigate` を追加:
+
+```ts
+export function usePresenterBroadcast(
+	fileName: string,
+	pairId: string,
+	pdfpcConfig: ResolvedPdfpcConfigV2,
+	pdf: File,
+	isBlackout: boolean,
+	pageNumber: number,
+	onNavigate?: (direction: "next" | "prev" | "home" | "end") => void,
+) {
+```
+
+`handleMessage` の switch 内に case 追加:
+
+```ts
+case "navigate":
+	console.log("[Presenter Broadcast] Navigate:", action.direction);
+	onNavigate?.(action.direction);
+	break;
+```
+
+- [ ] **Step 3: presentation 側の送信 helper をファイル末尾に追加**
+
+`src/broadcast/presentation.ts` の末尾に追加:
+
+```ts
+export function sendNavigate(
+	fileName: string,
+	pairId: string,
+	direction: "next" | "prev" | "home" | "end",
+): void {
+	const channel = getBroadcastChannel(fileName, pairId);
+	channel.postMessage({
+		from: "presentation",
+		command: "navigate",
+		direction,
+	} satisfies PresentationAction);
+}
+```
+
+- [ ] **Step 4: index.ts に re-export**
+
+`src/broadcast/index.ts`:
+
+```ts
+export { sendNavigate, usePresentationBroadcast } from "./presentation";
+```
+
+- [ ] **Step 5: 型チェック**
+
+Run: `pnpm tsc -b`
+Expected: エラーなし（`presenter.tsx` で新しい optional パラメータを使っていないが optional なので OK）
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/broadcast/
+git commit -m "feat(broadcast): navigate コマンドを追加"
+```
+
+---
+
+## Task 3: presenter に `navigate` 受信時のロジックを接続
+
+**Files:**
+- Modify: `src/routes/(main)/presenter.tsx`
+
+- [ ] **Step 1: `onNavigate` ハンドラを作る**
+
+`src/routes/(main)/presenter.tsx` の `PresenterContent` 関数内、`usePresenterBroadcast` 呼び出しの直前に追加:
+
+```ts
+const handleNavigate = useCallback(
+	(direction: "next" | "prev" | "home" | "end") => {
+		switch (direction) {
+			case "next":
+				nextSlide();
+				break;
+			case "prev":
+				prevSlide();
+				break;
+			case "home":
+				jumpToFirstSlide();
+				break;
+			case "end":
+				jumpToLastSlide();
+				break;
+		}
+	},
+	// biome-ignore lint/correctness/useExhaustiveDependencies: nextSlide 等は毎レンダーで作り直される
+	[pageNumber, pdfpcConfig.totalOverlays],
+);
+```
+
+- [ ] **Step 2: `usePresenterBroadcast` に渡す**
+
+```ts
+usePresenterBroadcast(
+	fileName,
+	pairId,
+	pdfpcConfig,
+	pdf,
+	isBlackout,
+	pageNumber,
+	handleNavigate,
+);
+```
+
+- [ ] **Step 3: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/routes/\(main\)/presenter.tsx
+git commit -m "feat(presenter): navigate コマンドを受信してページ送りに接続"
+```
+
+---
+
+## Task 4: presentation 側ナビゲーションショートカットフック
+
+**Files:**
+- Create: `src/routes/presentation/-hooks/use-presentation-shortcut.ts`
+
+- [ ] **Step 1: フックを作成**
+
+```ts
+import { useEffect, useEffectEvent } from "react";
+import { sendNavigate } from "#src/broadcast";
+
+export function usePresentationShortcut(fileName: string, pairId: string) {
+	const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
+		if (event.defaultPrevented) return;
+
+		switch (event.key) {
+			case " ":
+			case "ArrowRight":
+			case "PageDown":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "next");
+				break;
+			case "ArrowLeft":
+			case "PageUp":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "prev");
+				break;
+			case "Home":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "home");
+				break;
+			case "End":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "end");
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const abortController = new AbortController();
+		window.addEventListener("keydown", onKeyDown, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, []);
+}
+```
+
+- [ ] **Step 2: presentation に組み込む**
+
+`src/routes/presentation/index.tsx` の `PresentationView` コンポーネント（既存の `onKeyDown` 定義の近く）に:
+
+```ts
+import { usePresentationShortcut } from "./-hooks/use-presentation-shortcut";
+
+// PresentationView 内に fileName と pairId が必要。PresentationBroadcastData から渡す
+```
+
+**props に `fileName` と `pairId` を追加する**:
+
+`PresentationBroadcastData` の return:
+
+```ts
+return <PresentationView {...initData} localPdf={pdf} fileName={fileName} pairId={pairId} />;
+```
+
+`PresentationView` のシグネチャ修正:
+
+```ts
+function PresentationView({
+	pdfpcConfig,
+	pdfData,
+	pageNumber,
+	isBlackout,
+	localPdf,
+	fileName,
+	pairId,
+}: {
+	pdfpcConfig: ResolvedPdfpcConfigV2;
+	pdfData: ArrayBuffer;
+	pageNumber: number;
+	isBlackout: boolean;
+	localPdf?: File | FileSystemFileHandle;
+	fileName: string;
+	pairId: string;
+}) {
+```
+
+body 内（`useEffect` でキーバインドを付けている既存箇所のすぐ上）に:
+
+```ts
+usePresentationShortcut(fileName, pairId);
+```
+
+- [ ] **Step 3: 動作確認（手動）**
+
+Run: `pnpm dev`
+手順:
+1. ブラウザで `http://localhost:6123` を開く
+2. PDF をロードしてプレゼンターを開く
+3. presentation 画面を別タブで開く
+4. presentation 画面にフォーカスして `Space` / `→` / `←` / `Home` / `End` を押すとページが進む/戻る/先頭/末尾へ飛ぶことを確認
+
+Expected: presenter と presentation の両画面でページ同期
+
+- [ ] **Step 4: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/routes/presentation/
+git commit -m "feat(presentation): バックアップ用ページ送りショートカットを追加"
+```
+
+---
+
+## Task 5: pointer-state atoms とテスト
+
+**Files:**
+- Create: `src/lib/pointer-state.ts`
+- Create: `src/lib/pointer-state.test.ts`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`src/lib/pointer-state.test.ts`:
+
+```ts
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+import {
+	addPenPoint,
+	addPenStroke,
+	clearPenStrokes,
+	endPenStroke,
+	laserPosAtom,
+	penStrokesAtom,
+	toolModeAtom,
+} from "./pointer-state.ts";
+
+describe("toolModeAtom", () => {
+	it("初期値は none", () => {
+		const store = createStore();
+		expect(store.get(toolModeAtom)).toBe("none");
+	});
+	it("laser/pen/none に切り替えできる", () => {
+		const store = createStore();
+		store.set(toolModeAtom, "laser");
+		expect(store.get(toolModeAtom)).toBe("laser");
+		store.set(toolModeAtom, "pen");
+		expect(store.get(toolModeAtom)).toBe("pen");
+		store.set(toolModeAtom, "none");
+		expect(store.get(toolModeAtom)).toBe("none");
+	});
+});
+
+describe("laserPosAtom", () => {
+	it("初期値は null", () => {
+		const store = createStore();
+		expect(store.get(laserPosAtom)).toBe(null);
+	});
+});
+
+describe("penStrokes 操作", () => {
+	it("addPenStroke で新規ストローク追加", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0.1, y: 0.2 });
+		expect(store.get(penStrokesAtom)).toEqual([
+			{ id: "s1", points: [{ x: 0.1, y: 0.2 }], ended: false },
+		]);
+	});
+
+	it("addPenPoint で既存ストロークに点追加", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0.1, y: 0.2 });
+		store.set(addPenPoint, { strokeId: "s1", x: 0.3, y: 0.4 });
+		expect(store.get(penStrokesAtom)[0].points).toEqual([
+			{ x: 0.1, y: 0.2 },
+			{ x: 0.3, y: 0.4 },
+		]);
+	});
+
+	it("addPenPoint で未知の strokeId ならストロークを自動作成", () => {
+		const store = createStore();
+		store.set(addPenPoint, { strokeId: "s_new", x: 0.5, y: 0.5 });
+		expect(store.get(penStrokesAtom)).toEqual([
+			{ id: "s_new", points: [{ x: 0.5, y: 0.5 }], ended: false },
+		]);
+	});
+
+	it("endPenStroke で ended=true", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0, y: 0 });
+		store.set(endPenStroke, { strokeId: "s1" });
+		expect(store.get(penStrokesAtom)[0].ended).toBe(true);
+	});
+
+	it("clearPenStrokes で空", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0, y: 0 });
+		store.set(clearPenStrokes);
+		expect(store.get(penStrokesAtom)).toEqual([]);
+	});
+});
+```
+
+- [ ] **Step 2: 実行して失敗を確認**
+
+Run: `pnpm test src/lib/pointer-state.test.ts`
+Expected: FAIL — モジュール未定義
+
+- [ ] **Step 3: 実装を追加**
+
+`src/lib/pointer-state.ts`:
+
+```ts
+import { atom } from "jotai";
+
+export type ToolMode = "none" | "laser" | "pen";
+
+export interface NormalizedPoint {
+	x: number;
+	y: number;
+}
+
+export interface PenStroke {
+	id: string;
+	points: NormalizedPoint[];
+	ended: boolean;
+}
+
+export const toolModeAtom = atom<ToolMode>("none");
+export const laserPosAtom = atom<NormalizedPoint | null>(null);
+export const penStrokesAtom = atom<PenStroke[]>([]);
+
+export const addPenStroke = atom(
+	null,
+	(get, set, payload: { strokeId: string; x: number; y: number }) => {
+		const strokes = get(penStrokesAtom);
+		if (strokes.some((s) => s.id === payload.strokeId)) return;
+		set(penStrokesAtom, [
+			...strokes,
+			{
+				id: payload.strokeId,
+				points: [{ x: payload.x, y: payload.y }],
+				ended: false,
+			},
+		]);
+	},
+);
+
+export const addPenPoint = atom(
+	null,
+	(get, set, payload: { strokeId: string; x: number; y: number }) => {
+		const strokes = get(penStrokesAtom);
+		const existing = strokes.find((s) => s.id === payload.strokeId);
+		if (!existing) {
+			set(penStrokesAtom, [
+				...strokes,
+				{
+					id: payload.strokeId,
+					points: [{ x: payload.x, y: payload.y }],
+					ended: false,
+				},
+			]);
+			return;
+		}
+		set(
+			penStrokesAtom,
+			strokes.map((s) =>
+				s.id === payload.strokeId
+					? { ...s, points: [...s.points, { x: payload.x, y: payload.y }] }
+					: s,
+			),
+		);
+	},
+);
+
+export const endPenStroke = atom(
+	null,
+	(get, set, payload: { strokeId: string }) => {
+		const strokes = get(penStrokesAtom);
+		set(
+			penStrokesAtom,
+			strokes.map((s) =>
+				s.id === payload.strokeId ? { ...s, ended: true } : s,
+			),
+		);
+	},
+);
+
+export const clearPenStrokes = atom(null, (_get, set) => {
+	set(penStrokesAtom, []);
+});
+```
+
+- [ ] **Step 4: テスト成功確認**
+
+Run: `pnpm test src/lib/pointer-state.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add src/lib/pointer-state.ts src/lib/pointer-state.test.ts
+git commit -m "feat(pointer): ツールモード/レーザー/ペンストローク atom を追加"
+```
+
+---
+
+## Task 6: PointerOverlay コンポーネント
+
+**Files:**
+- Create: `src/components/PointerOverlay.tsx`
+
+- [ ] **Step 1: オーバーレイを作る**
+
+```tsx
+import { useAtomValue } from "jotai";
+import {
+	laserPosAtom,
+	penStrokesAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+import { cn } from "#src/lib/utils.ts";
+
+interface PointerOverlayProps {
+	className?: string;
+}
+
+const PEN_COLOR = "#ef4444";
+const PEN_WIDTH = 0.004; // 正規化座標系でのおおよその太さ (viewBox=1 基準)
+
+export function PointerOverlay({ className }: PointerOverlayProps) {
+	const toolMode = useAtomValue(toolModeAtom);
+	const laserPos = useAtomValue(laserPosAtom);
+	const strokes = useAtomValue(penStrokesAtom);
+
+	if (toolMode === "none" && strokes.length === 0) return null;
+
+	return (
+		<svg
+			className={cn("absolute inset-0 pointer-events-none", className)}
+			viewBox="0 0 1 1"
+			preserveAspectRatio="none"
+			aria-hidden="true"
+		>
+			{strokes.map((stroke) =>
+				stroke.points.length === 0 ? null : (
+					<polyline
+						key={stroke.id}
+						points={stroke.points.map((p) => `${p.x},${p.y}`).join(" ")}
+						fill="none"
+						stroke={PEN_COLOR}
+						strokeWidth={PEN_WIDTH}
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						vectorEffect="non-scaling-stroke"
+					/>
+				),
+			)}
+			{toolMode === "laser" && laserPos !== null ? (
+				<circle
+					cx={laserPos.x}
+					cy={laserPos.y}
+					r={0.008}
+					fill={PEN_COLOR}
+					opacity={0.8}
+					style={{ mixBlendMode: "multiply" }}
+				/>
+			) : null}
+		</svg>
+	);
+}
+```
+
+メモ: `vectorEffect="non-scaling-stroke"` でアスペクト比に関わらず線幅をピクセル相当に保つ。ただしこの SVG は viewBox 1x1 なので stroke-width は px 換算になる（CSS pixel units）。実サイズは `preserveAspectRatio="none"` でコンテナに合わせて引き伸ばされる。
+
+- [ ] **Step 2: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/components/PointerOverlay.tsx
+git commit -m "feat(components): PointerOverlay を追加"
+```
+
+---
+
+## Task 7: ツール系 broadcast 型と送信 helper
+
+**Files:**
+- Create: `src/broadcast/tools.ts`
+- Modify: `src/broadcast/index.ts`
+
+- [ ] **Step 1: tools.ts を作成**
+
+```ts
+import { getBroadcastChannel } from "./channel";
+import type {
+	BroadcastAction,
+	PresentationAction,
+	PresenterAction,
+} from "./types";
+
+// 双方向コマンド: 両方のマップに宣言することで from 問わず送信可能に
+declare global {
+	interface PresenterCommandMap {
+		"tool-mode": { mode: "none" | "laser" | "pen" };
+		"pointer-move": { x: number; y: number };
+		"pointer-leave": Record<string, never>;
+		"pen-stroke-start": { strokeId: string; x: number; y: number };
+		"pen-stroke-point": { strokeId: string; x: number; y: number };
+		"pen-stroke-end": { strokeId: string };
+		"pen-clear": Record<string, never>;
+	}
+	interface PresentationCommandMap {
+		"tool-mode": { mode: "none" | "laser" | "pen" };
+		"pointer-move": { x: number; y: number };
+		"pointer-leave": Record<string, never>;
+		"pen-stroke-start": { strokeId: string; x: number; y: number };
+		"pen-stroke-point": { strokeId: string; x: number; y: number };
+		"pen-stroke-end": { strokeId: string };
+		"pen-clear": Record<string, never>;
+	}
+}
+
+import type { ToolMode } from "#src/lib/pointer-state.ts";
+
+export type ToolSide = "presenter" | "presentation";
+
+type ToolCommand =
+	| { command: "tool-mode"; mode: ToolMode }
+	| { command: "pointer-move"; x: number; y: number }
+	| { command: "pointer-leave" }
+	| { command: "pen-stroke-start"; strokeId: string; x: number; y: number }
+	| { command: "pen-stroke-point"; strokeId: string; x: number; y: number }
+	| { command: "pen-stroke-end"; strokeId: string }
+	| { command: "pen-clear" };
+
+export function sendTool(
+	fileName: string,
+	pairId: string,
+	from: ToolSide,
+	cmd: ToolCommand,
+): void {
+	const channel = getBroadcastChannel(fileName, pairId);
+	// postMessage は any を受け付けるため厳密な satisfies は不要。
+	// 型安全性は呼び出し側の引数型 (ToolCommand, ToolSide) で担保される
+	channel.postMessage({ from, ...cmd });
+}
+
+export type ToolAction = Extract<
+	PresenterAction | PresentationAction,
+	{
+		command:
+			| "tool-mode"
+			| "pointer-move"
+			| "pointer-leave"
+			| "pen-stroke-start"
+			| "pen-stroke-point"
+			| "pen-stroke-end"
+			| "pen-clear";
+	}
+>;
+```
+
+- [ ] **Step 2: index.ts に export**
+
+`src/broadcast/index.ts`:
+
+```ts
+export { sendTool, type ToolAction, type ToolSide } from "./tools";
+```
+
+**注意**: `ToolMode` は `#src/lib/pointer-state.ts` から export されているため broadcast からは再 export しない。また `tools.ts` の `declare global` を有効化するために、どこからか import される必要がある。`index.ts` で re-export していれば OK。
+
+- [ ] **Step 3: 型チェック**
+
+Run: `pnpm tsc -b`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/broadcast/
+git commit -m "feat(broadcast): ツール系双方向コマンド (pointer/pen/tool-mode) を定義"
+```
+
+---
+
+## Task 8: useToolBroadcast フック（両側共通の受信処理）
+
+**Files:**
+- Modify: `src/broadcast/tools.ts`
+
+- [ ] **Step 1: 受信フックを追加**
+
+`src/broadcast/tools.ts` の末尾に追加:
+
+```ts
+import { useEffect, useEffectEvent } from "react";
+import { useSetAtom } from "jotai";
+import {
+	addPenPoint,
+	addPenStroke,
+	clearPenStrokes,
+	endPenStroke,
+	laserPosAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+
+/**
+ * ツール系コマンドを受信して pointer-state atoms を更新する。
+ * 自身が送信したメッセージは BroadcastChannel の仕様により受信されないため、
+ * 送信側は別途 local atom を更新すること。
+ */
+export function useToolBroadcast(
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const setToolMode = useSetAtom(toolModeAtom);
+	const setLaserPos = useSetAtom(laserPosAtom);
+	const doAddPenStroke = useSetAtom(addPenStroke);
+	const doAddPenPoint = useSetAtom(addPenPoint);
+	const doEndPenStroke = useSetAtom(endPenStroke);
+	const doClearStrokes = useSetAtom(clearPenStrokes);
+
+	const onAction = useEffectEvent((action: ToolAction) => {
+		switch (action.command) {
+			case "tool-mode":
+				setToolMode(action.mode);
+				break;
+			case "pointer-move":
+				setLaserPos({ x: action.x, y: action.y });
+				break;
+			case "pointer-leave":
+				setLaserPos(null);
+				break;
+			case "pen-stroke-start":
+				doAddPenStroke({
+					strokeId: action.strokeId,
+					x: action.x,
+					y: action.y,
+				});
+				break;
+			case "pen-stroke-point":
+				doAddPenPoint({
+					strokeId: action.strokeId,
+					x: action.x,
+					y: action.y,
+				});
+				break;
+			case "pen-stroke-end":
+				doEndPenStroke({ strokeId: action.strokeId });
+				break;
+			case "pen-clear":
+				doClearStrokes();
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const channel = getBroadcastChannel(fileName, pairId);
+		const abortController = new AbortController();
+		const listener = (event: MessageEvent) => {
+			const action = event.data as BroadcastAction;
+			if (action.from === selfSide) return;
+			if (
+				action.command === "tool-mode" ||
+				action.command === "pointer-move" ||
+				action.command === "pointer-leave" ||
+				action.command === "pen-stroke-start" ||
+				action.command === "pen-stroke-point" ||
+				action.command === "pen-stroke-end" ||
+				action.command === "pen-clear"
+			) {
+				onAction(action as ToolAction);
+			}
+		};
+		channel.addEventListener("message", listener, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, [fileName, pairId, selfSide]);
+}
+```
+
+- [ ] **Step 2: index.ts に export**
+
+```ts
+export { sendTool, useToolBroadcast, type ToolAction, type ToolSide } from "./tools";
+```
+
+- [ ] **Step 3: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/broadcast/
+git commit -m "feat(broadcast): useToolBroadcast で双方向ツールコマンド受信"
+```
+
+---
+
+## Task 9: ツールショートカットフック（L/D/E/Esc）
+
+**Files:**
+- Create: `src/routes/-hooks/use-tool-shortcut.ts`
+
+- [ ] **Step 1: フック作成**
+
+```ts
+import { useAtom, useSetAtom } from "jotai";
+import { useEffect, useEffectEvent } from "react";
+import { sendTool, type ToolSide } from "#src/broadcast";
+import {
+	clearPenStrokes,
+	type ToolMode,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+
+export function useToolShortcut(
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const [toolMode, setToolMode] = useAtom(toolModeAtom);
+	const doClearStrokes = useSetAtom(clearPenStrokes);
+
+	const changeMode = useEffectEvent((next: ToolMode) => {
+		setToolMode(next);
+		sendTool(fileName, pairId, selfSide, { command: "tool-mode", mode: next });
+	});
+
+	const clearPen = useEffectEvent(() => {
+		doClearStrokes();
+		sendTool(fileName, pairId, selfSide, { command: "pen-clear" });
+	});
+
+	const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
+		if (event.defaultPrevented) return;
+		// IME やテキスト入力中は無視
+		const target = event.target as HTMLElement | null;
+		if (
+			target &&
+			(target.tagName === "INPUT" ||
+				target.tagName === "TEXTAREA" ||
+				target.isContentEditable)
+		) {
+			return;
+		}
+
+		switch (event.key) {
+			case "l":
+			case "L":
+				event.preventDefault();
+				changeMode(toolMode === "laser" ? "none" : "laser");
+				break;
+			case "d":
+			case "D":
+				event.preventDefault();
+				changeMode(toolMode === "pen" ? "none" : "pen");
+				break;
+			case "e":
+			case "E":
+				event.preventDefault();
+				clearPen();
+				break;
+			case "Escape":
+				if (toolMode !== "none") {
+					event.preventDefault();
+					changeMode("none");
+				}
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const abortController = new AbortController();
+		window.addEventListener("keydown", onKeyDown, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, []);
+}
+```
+
+- [ ] **Step 2: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/routes/-hooks/use-tool-shortcut.ts
+git commit -m "feat(hooks): useToolShortcut (L/D/E/Esc) を追加"
+```
+
+---
+
+## Task 10: pointer イベント発火 hook（両画面共通）
+
+**Files:**
+- Create: `src/routes/-hooks/use-pointer-emitter.ts`
+
+- [ ] **Step 1: フック作成**
+
+```ts
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+	type RefObject,
+	useCallback,
+	useEffect,
+	useEffectEvent,
+	useRef,
+} from "react";
+import { sendTool, type ToolSide } from "#src/broadcast";
+import {
+	addPenPoint,
+	addPenStroke,
+	endPenStroke,
+	laserPosAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+
+/**
+ * 指定要素内でのマウス移動/クリックを観察し、tool-mode に応じて
+ * ローカルの pointer-state を更新 + broadcast する。
+ * - laser: pointermove で座標を更新/送信
+ * - pen: pointerdown で新規ストローク、drag 中 pointermove で点追加、pointerup で終了
+ */
+export function usePointerEmitter(
+	containerRef: RefObject<HTMLElement | null>,
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const toolMode = useAtomValue(toolModeAtom);
+	const setLaserPos = useSetAtom(laserPosAtom);
+	const doAddPenStroke = useSetAtom(addPenStroke);
+	const doAddPenPoint = useSetAtom(addPenPoint);
+	const doEndPenStroke = useSetAtom(endPenStroke);
+
+	const strokeIdRef = useRef<string | null>(null);
+	const pendingPointRef = useRef<{ x: number; y: number } | null>(null);
+	const rafHandleRef = useRef<number | null>(null);
+
+	const flushPendingPoint = useEffectEvent(() => {
+		rafHandleRef.current = null;
+		const p = pendingPointRef.current;
+		if (!p) return;
+		pendingPointRef.current = null;
+
+		if (toolMode === "laser") {
+			setLaserPos(p);
+			sendTool(fileName, pairId, selfSide, {
+				command: "pointer-move",
+				x: p.x,
+				y: p.y,
+			});
+		} else if (toolMode === "pen" && strokeIdRef.current) {
+			doAddPenPoint({ strokeId: strokeIdRef.current, x: p.x, y: p.y });
+			sendTool(fileName, pairId, selfSide, {
+				command: "pen-stroke-point",
+				strokeId: strokeIdRef.current,
+				x: p.x,
+				y: p.y,
+			});
+		}
+	});
+
+	const schedule = useCallback(
+		(p: { x: number; y: number }) => {
+			pendingPointRef.current = p;
+			if (rafHandleRef.current !== null) return;
+			rafHandleRef.current = requestAnimationFrame(flushPendingPoint);
+		},
+		[flushPendingPoint],
+	);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		if (toolMode === "none") return;
+
+		const abortController = new AbortController();
+
+		const toNormalized = (event: PointerEvent): { x: number; y: number } => {
+			const rect = el.getBoundingClientRect();
+			const x = (event.clientX - rect.left) / rect.width;
+			const y = (event.clientY - rect.top) / rect.height;
+			return {
+				x: Math.max(0, Math.min(1, x)),
+				y: Math.max(0, Math.min(1, y)),
+			};
+		};
+
+		const onMove = (event: PointerEvent) => {
+			schedule(toNormalized(event));
+		};
+
+		const onLeave = () => {
+			pendingPointRef.current = null;
+			if (toolMode === "laser") {
+				setLaserPos(null);
+				sendTool(fileName, pairId, selfSide, { command: "pointer-leave" });
+			}
+		};
+
+		const onDown = (event: PointerEvent) => {
+			if (toolMode !== "pen") return;
+			if (event.button !== 0) return;
+			event.preventDefault();
+			const p = toNormalized(event);
+			const strokeId =
+				typeof crypto.randomUUID === "function"
+					? crypto.randomUUID()
+					: `stroke-${Date.now()}-${Math.random()}`;
+			strokeIdRef.current = strokeId;
+			doAddPenStroke({ strokeId, x: p.x, y: p.y });
+			sendTool(fileName, pairId, selfSide, {
+				command: "pen-stroke-start",
+				strokeId,
+				x: p.x,
+				y: p.y,
+			});
+			(event.target as Element).setPointerCapture?.(event.pointerId);
+		};
+
+		const onUp = (event: PointerEvent) => {
+			if (!strokeIdRef.current) return;
+			const strokeId = strokeIdRef.current;
+			strokeIdRef.current = null;
+			doEndPenStroke({ strokeId });
+			sendTool(fileName, pairId, selfSide, {
+				command: "pen-stroke-end",
+				strokeId,
+			});
+			(event.target as Element).releasePointerCapture?.(event.pointerId);
+		};
+
+		el.addEventListener("pointermove", onMove, { signal: abortController.signal });
+		el.addEventListener("pointerleave", onLeave, { signal: abortController.signal });
+		el.addEventListener("pointerdown", onDown, { signal: abortController.signal });
+		el.addEventListener("pointerup", onUp, { signal: abortController.signal });
+		el.addEventListener("pointercancel", onUp, { signal: abortController.signal });
+
+		return () => {
+			abortController.abort();
+			if (rafHandleRef.current !== null) {
+				cancelAnimationFrame(rafHandleRef.current);
+				rafHandleRef.current = null;
+			}
+		};
+	}, [containerRef, toolMode, fileName, pairId, selfSide, schedule]);
+}
+```
+
+- [ ] **Step 2: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add src/routes/-hooks/use-pointer-emitter.ts
+git commit -m "feat(hooks): usePointerEmitter でポインタ/ペンをブロードキャスト"
+```
+
+---
+
+## Task 11: presenter 側統合（overlay + tool + pointer + ページ遷移クリア）
+
+**Files:**
+- Modify: `src/routes/(main)/presenter.tsx`
+- Modify: `src/routes/(main)/-presenter/SlideStage.tsx`
+
+- [ ] **Step 1: SlideStage で overlay を子として受け取れるようにする**
+
+`src/routes/(main)/-presenter/SlideStage.tsx`:
+
+```tsx
+import type { ClassValue } from "clsx";
+import type { PDFDocumentProxy } from "pdfjs-dist";
+import type { ReactNode, RefObject } from "react";
+import { PdfPage } from "#src/components/PdfPage.tsx";
+import { cn } from "#src/lib/utils.ts";
+
+export const SlideStage = function SlideStage({
+	pdfProxy,
+	pageNumber,
+	className,
+	ref,
+	children,
+}: {
+	pdfProxy: PDFDocumentProxy;
+	pageNumber: number;
+	className?: ClassValue;
+	ref?: RefObject<HTMLElement | null>;
+	children?: ReactNode;
+}) {
+	return (
+		<section className={cn("relative", className)} ref={ref}>
+			<PdfPage
+				pdfProxy={pdfProxy}
+				pageNumber={pageNumber}
+				className="absolute inset-0"
+			/>
+			{children}
+		</section>
+	);
+};
+```
+
+- [ ] **Step 2: presenter.tsx に統合**
+
+`src/routes/(main)/presenter.tsx` の `PresenterContent` 内:
+
+先頭の import 追加:
+
+```ts
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
+import { sendTool, useToolBroadcast } from "#src/broadcast";
+import { PointerOverlay } from "#src/components/PointerOverlay.tsx";
+import { clearPenStrokes } from "#src/lib/pointer-state.ts";
+import { useToolShortcut } from "../-hooks/use-tool-shortcut";
+import { usePointerEmitter } from "../-hooks/use-pointer-emitter";
+```
+
+`PresenterContent` 内、既存の `usePresenterBroadcast` の下辺りに追加:
+
+```ts
+useToolBroadcast(fileName, pairId, "presenter");
+useToolShortcut(fileName, pairId, "presenter");
+usePointerEmitter(slideStageRef, fileName, pairId, "presenter");
+
+// ページ遷移時にペンストロークを自動クリア
+const doClearStrokes = useSetAtom(clearPenStrokes);
+useEffect(() => {
+	doClearStrokes();
+	sendTool(fileName, pairId, "presenter", { command: "pen-clear" });
+}, [pageNumber, fileName, pairId, doClearStrokes]);
+```
+
+`SlideStage` の children として `PointerOverlay` を追加:
+
+```tsx
+<SlideStage
+	pdfProxy={pdfProxy}
+	pageNumber={pageNumber}
+	className="aspect-video h-full max-w-full place-self-center"
+	ref={slideStageRef}
+>
+	<PointerOverlay />
+</SlideStage>
+```
+
+- [ ] **Step 3: 手動動作確認**
+
+Run: `pnpm dev`
+1. ブラウザで PDF を開いてプレゼンターを開く
+2. `L` を押す → 自画面でカーソルに赤ドットが追従
+3. もう一度 `L` で消える
+4. `D` を押してスライド上でドラッグ → 赤い線が描かれる
+5. 次のページへ進む → 線が消える
+6. `D` でペンに戻り、何本か描いてから `E` → 消える
+7. `Esc` → ツールモード none
+
+- [ ] **Step 4: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/routes/\(main\)/
+git commit -m "feat(presenter): PointerOverlay とツール操作を統合"
+```
+
+---
+
+## Task 12: presentation 側統合（overlay + tool + pointer）
+
+**Files:**
+- Modify: `src/routes/presentation/index.tsx`
+- Modify: `src/routes/presentation/-SlideStage.tsx`
+
+- [ ] **Step 1: SlideStage で overlay を子として受け取る**
+
+`src/routes/presentation/-SlideStage.tsx`:
+
+```tsx
+import type { ClassValue } from "clsx";
+import type { PDFDocumentProxy } from "pdfjs-dist";
+import type { ReactNode, RefObject } from "react";
+import { PdfPage } from "#src/components/PdfPage.tsx";
+import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
+import { cn } from "#src/lib/utils.ts";
+
+interface SlideStageProps {
+	pdfProxy: PDFDocumentProxy;
+	pdfpcConfig: ResolvedPdfpcConfigV2;
+	currentPageNumber: number;
+	isBlackout: boolean;
+	className?: ClassValue;
+	stageRef?: RefObject<HTMLDivElement | null>;
+	children?: ReactNode;
+}
+
+function preloadSlide(
+	pdfpcConfig: ResolvedPdfpcConfigV2,
+	pageNumber: number,
+): number[] {
+	const pages = pdfpcConfig.pages.flat();
+	const currentIndex = pages.findIndex((p) => p.pageNumber === pageNumber);
+	if (currentIndex === -1) return [pageNumber];
+	const start = Math.max(0, currentIndex - 10);
+	const end = currentIndex + 10;
+	return pages.slice(start, end + 1).map((p) => p.pageNumber);
+}
+
+export function SlideStage({
+	pdfProxy,
+	pdfpcConfig,
+	currentPageNumber,
+	isBlackout,
+	className,
+	stageRef,
+	children,
+}: SlideStageProps) {
+	const preloadPages = preloadSlide(pdfpcConfig, currentPageNumber);
+	return (
+		<div className={cn("relative", className)} ref={stageRef}>
+			{preloadPages.map((pageNumber) => (
+				<PdfPage
+					key={pageNumber}
+					pdfProxy={pdfProxy}
+					pageNumber={pageNumber}
+					className={[
+						"absolute inset-0",
+						{
+							"opacity-0 pointer-events-none":
+								pageNumber !== currentPageNumber || isBlackout,
+						},
+					]}
+				/>
+			))}
+			{children}
+		</div>
+	);
+}
+```
+
+- [ ] **Step 2: PresentationView に統合**
+
+`src/routes/presentation/index.tsx` の import 追加:
+
+```ts
+import { useRef } from "react";
+import { useToolBroadcast } from "#src/broadcast";
+import { PointerOverlay } from "#src/components/PointerOverlay.tsx";
+import { useToolShortcut } from "#src/routes/-hooks/use-tool-shortcut";
+import { usePointerEmitter } from "#src/routes/-hooks/use-pointer-emitter";
+```
+
+`PresentationView` 内（既存の `onKeyDown` 定義より上に）:
+
+```ts
+const stageRef = useRef<HTMLDivElement | null>(null);
+
+useToolBroadcast(fileName, pairId, "presentation");
+useToolShortcut(fileName, pairId, "presentation");
+usePointerEmitter(stageRef, fileName, pairId, "presentation");
+```
+
+JSX 修正:
+
+```tsx
+<SlideStage
+	pdfProxy={pdfProxy}
+	pdfpcConfig={pdfpcConfig}
+	currentPageNumber={currentPageNumber}
+	isBlackout={currentIsBlackout}
+	stageRef={stageRef}
+>
+	<PointerOverlay />
+</SlideStage>
+```
+
+- [ ] **Step 3: 手動動作確認**
+
+Run: `pnpm dev`
+1. presenter と presentation を両方開く
+2. presenter 側で `L` → 両画面でレーザーが同期
+3. presentation 側で `L` → 両画面でレーザーが同期（双方向）
+4. どちら側で `D` にしてドラッグしても両画面に描画が出る
+5. ページ遷移すると両画面で線が消える
+6. `E` で消える
+
+- [ ] **Step 4: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add src/routes/presentation/
+git commit -m "feat(presentation): PointerOverlay とツール操作を統合"
+```
+
+---
+
+## Task 13: presentation メニューのツール中抑制
+
+**Files:**
+- Modify: `src/routes/presentation/-Menu.tsx`
+
+- [ ] **Step 1: toolMode を購読し、pointer リスナーを条件付きに**
+
+`src/routes/presentation/-Menu.tsx` の import に追加:
+
+```ts
+import { useAtomValue } from "jotai";
+import { toolModeAtom } from "#src/lib/pointer-state.ts";
+```
+
+コンポーネント内（既存の useEffect より上）:
+
+```ts
+const toolMode = useAtomValue(toolModeAtom);
+```
+
+既存の `useEffect(() => { scheduleHide(); ... })` を修正し、toolMode を依存に、かつ ON 時はリスナーを張らず visible を false に固定:
+
+```ts
+useEffect(() => {
+	if (toolMode !== "none") {
+		// ツール使用中はメニューを出さない
+		if (hideTimerRef.current) {
+			window.clearTimeout(hideTimerRef.current);
+			hideTimerRef.current = null;
+		}
+		setVisible(false);
+		return;
+	}
+
+	scheduleHide();
+
+	const onPointerMove = (): void => {
+		showAndResetTimer();
+	};
+	const onPointerDown = (): void => {
+		showAndResetTimer();
+	};
+
+	window.addEventListener("pointermove", onPointerMove, { passive: true });
+	window.addEventListener("pointerdown", onPointerDown, { passive: true });
+
+	return () => {
+		window.removeEventListener("pointermove", onPointerMove);
+		window.removeEventListener("pointerdown", onPointerDown);
+		if (hideTimerRef.current) {
+			window.clearTimeout(hideTimerRef.current);
+			hideTimerRef.current = null;
+		}
+	};
+}, [toolMode]);
+```
+
+- [ ] **Step 2: 手動動作確認**
+
+Run: `pnpm dev`
+1. presentation 画面でマウスを動かす → メニューが出る
+2. `L` を押す → メニューが即座に消え、以降カーソル移動でも出ない
+3. `Esc` → 通常挙動に戻る
+
+- [ ] **Step 3: 型チェックと lint**
+
+Run: `pnpm tsc -b && pnpm lint`
+Expected: エラーなし
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add src/routes/presentation/-Menu.tsx
+git commit -m "feat(presentation): ツールモード中はメニュー自動表示を抑制"
+```
+
+---
+
+## Task 14: 最終検証
+
+**Files:** なし（確認のみ）
+
+- [ ] **Step 1: 全体型チェック**
+
+Run: `pnpm tsc -b`
+Expected: エラーなし
+
+- [ ] **Step 2: lint と format チェック**
+
+Run: `pnpm check`
+Expected: エラー/警告なし。もし format のみ差分があれば `pnpm format` を実行してコミット
+
+- [ ] **Step 3: 全テスト実行**
+
+Run: `pnpm test`
+Expected: `navigation-utils.test.ts`, `pointer-state.test.ts` が全て PASS
+
+- [ ] **Step 4: 本番ビルド**
+
+Run: `pnpm build`
+Expected: 成功
+
+- [ ] **Step 5: 統合手動テスト**
+
+Run: `pnpm dev`
+以下のシナリオを順に確認:
+
+**A. presentation からのページ送り**
+- presentation にフォーカス → `Space`/`→`/`PageDown` で次、`←`/`PageUp` で前、`Home`/`End` で先頭/末尾。presenter 画面と同期
+
+**B. レーザー双方向**
+- presenter で `L` → 両画面でレーザー表示
+- マウスを動かすと両画面で追従
+- presenter で `L` で OFF → 両画面消える
+- presentation で `L` → 両画面 ON、presentation のマウス移動が両画面に反映
+
+**C. ペン双方向**
+- presenter で `D` → ドラッグで両画面に赤線
+- presentation で `D` に切り替え → presentation 側でドラッグしても両画面に描画
+- 次ページに進む → 両画面で線が消える
+- 再度描いて `E` → 両画面で消える
+
+**D. メニュー抑制**
+- presentation 画面でマウス動かすとメニュー表示
+- `L` または `D` に入るとメニュー消えて以降出ない
+- `Esc` で元に戻る
+
+**E. エッジケース**
+- スライド領域外にカーソルを出す → レーザー消える
+- ペン描画中に領域外へドラッグ → ストロークは setPointerCapture で継続
+
+- [ ] **Step 6: 最終コミット（必要なら format 差分など）**
+
+```bash
+git status
+# 差分があれば
+git add -A
+git commit -m "chore: lint/format fixes"
+```
+
+---
+
+## 完了条件チェックリスト
+
+スペック `docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md` の完了条件に対応:
+
+- [x] presentation 画面で Space/矢印/PageUp/Down/Home/End でページが進む → Task 4
+- [x] `L` でレーザーが両画面に出る → Task 9, 11, 12
+- [x] `D` でペン、ページ遷移で自動クリア、`E` で手動クリア → Task 9, 10, 11
+- [x] ツール中は presentation メニュー自動表示を抑制 → Task 13
+- [x] `navigation-utils.ts` 新規ヘルパーの単体テストが通る → Task 1
+- [x] `pnpm tsc -b` / `pnpm lint` / `pnpm test` が通る → Task 14
+
+## スコープ外（将来タスク）
+
+- presentation 側からのブラックアウト/フリーズ操作
+- タッチ/ペンタブレット最適化（現状は Pointer Events 由来で動く可能性はあるが最適化はしていない）
+- ペンの色/太さカスタマイズ
+- CI (`.github/workflows/ci.yaml`) に test/lint/tsc を追加する（本 PR の後続タスク）

--- a/docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md
+++ b/docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md
@@ -1,0 +1,273 @@
+# Presentation 画面操作とポインターツール 設計書
+
+**作成日**: 2026-04-24
+**ステータス**: ドラフト
+
+## 背景
+
+PDFPW は現在、presentation 画面（観客向け）が完全に受動的である。presentation 側で可能なのは以下のローカル操作のみ:
+
+- `f`: フルスクリーン切替
+- `Tab` / `Escape`: オーバービュー開閉
+
+ページ送り、ブラックアウト、各種ツール操作は全て presenter 側で行う必要がある。また、ポインターツール（レーザー/ペン）が存在せず、ユーザーはカーソルでスライド内を指し示そうとするが、`pointermove` でメニューが自動表示されるため UX を損ねている。
+
+## ユースケース
+
+プレゼンター自身が通常は presenter 画面で操作するが、いざという時に presentation 画面側でもページ送りできる**冗長性を確保する**（バックアップ操作）。会場オペレータ補助や シングルディスプレイ運用はスコープ外。
+
+ポインターは **双方向同期モデル**: どちらの画面で操作しても、相手側にも同じポインター表示が出る。
+
+## スコープ
+
+### In Scope
+
+1. presentation 画面での基本ページ送り（Space / 矢印 / PageUp/Down / Home / End）
+2. レーザーポインター（`L` トグル）
+3. ペンツール（`D` トグル、赤 3px 固定、ページ遷移でクリア、`E` で手動クリア）
+4. ポインター/ペン中は presentation 側メニューの自動表示を抑制
+5. ナビゲーション解決ロジックを共通化し、初のユニットテストを導入
+
+### Out of Scope
+
+- presentation 側からのブラックアウト/ホワイトアウト/フリーズ操作
+- タッチ/ペンタブレット入力
+- ペンの色/太さカスタマイズ、ハイライター
+- 終了時のインク保存ダイアログ（PowerPoint 風）
+- ペン描画の PDF エクスポート
+- 他ユーザー操作（オーバービュー、ジャンプ入力）の presentation 側での完全再現
+
+## ユーザーストーリー
+
+1. **バックアップ操作**: presenter 画面のブラウザがクラッシュ/応答不能になった際、プレゼンターは presentation 画面にフォーカスを移し、`Space` や矢印キーでページ送りを継続できる。
+2. **レーザーポインター**: プレゼンターが `L` を押すと、自分のカーソル位置にレーザードットが表示され、同時に presentation 画面にも同位置（正規化座標）でレーザードットが同期表示される。もう一度 `L` または `Esc` で OFF。
+3. **ペン**: `D` でペンモードに入り、クリック&ドラッグで赤い線を描く。描画は両画面に同期。ページを変えると自動クリア。`E` で即座にクリア。
+4. **メニュー抑制**: ツールモード中は presentation 画面の自動表示メニューが出ない。カーソル移動でメニューに邪魔されずに指し示せる。
+
+## 設計詳細
+
+### 1. Broadcast プロトコル拡張
+
+全て `src/broadcast/types.ts` のグローバル宣言拡張パターンに合わせて追加する。以下のコマンドは **双方向**（presenter/presentation どちらからでも送信可能）とし、`from` フィールドで送信元を判別する。
+
+| コマンド | ペイロード | 意味 |
+|---|---|---|
+| `navigate` | `{ direction: "next" \| "prev" \| "home" \| "end" }` | ページ送り要求（通常は presentation → presenter） |
+| `tool-mode` | `{ mode: "none" \| "laser" \| "pen" }` | ツールモードの同期 |
+| `pointer-move` | `{ x: number; y: number }` | スライド領域内の正規化座標（0-1） |
+| `pointer-leave` | `{}` | カーソルがスライド領域外へ |
+| `pen-stroke-start` | `{ strokeId: string; x: number; y: number }` | ペンストローク開始点 |
+| `pen-stroke-point` | `{ strokeId: string; x: number; y: number }` | ストローク中の追加点 |
+| `pen-stroke-end` | `{ strokeId: string }` | ストローク終了 |
+| `pen-clear` | `{}` | ペン描画全消去 |
+
+**型定義の配置**:
+
+既存の `PresenterCommandMap` / `PresentationCommandMap` は送信元を型レベルで分けているが、双方向コマンドは**両方のマップに同じ形で宣言**する。これにより `from` の型制約は既存のままで、どちら側からも送信できるようになる。
+
+**正規化座標の定義**:
+
+スライド表示領域（黒帯を除いた実際の PDF ページが描画されている矩形）の左上を `(0, 0)`、右下を `(1, 1)` とする。受信側は自分の表示サイズに合わせてスケールする。両画面でアスペクト比は同じ（同一 PDF）なので位置ズレは起きない。
+
+**送信元自身へのエコー**:
+
+ツール操作は送信側の画面にも表示される必要がある。実装方針は「送信側は自分の local state を直接更新し、同時に broadcast する」。受信側は broadcast から state を更新する。結果として両画面が同じ state を持つ。
+
+### 2. Presentation 側ページ送り
+
+**新規フック**: `src/routes/presentation/-hooks/use-presentation-shortcut.ts`
+
+```
+Space / → / PageDown  → navigate { direction: "next" }
+← / PageUp            → navigate { direction: "prev" }
+Home                  → navigate { direction: "home" }
+End                   → navigate { direction: "end" }
+```
+
+既存のローカル処理 (`f`, `Tab`, `Escape`) は `presentation/index.tsx` に残す。
+
+`navigate` の direction は `"next" | "prev" | "home" | "end"` の4値のみ。ArrowUp/Down（ユーザースライド単位移動）、`g` ジャンプ、Shift+矢印（10スキップ）、Backspace（履歴戻り）は presentation 側では**実装しない**（バックアップ用途の最小セット Q4=B に準拠）。必要になれば後続タスクで `"next-user" | "prev-user"` 等を追加する。
+
+**presenter 側の解決**:
+
+presenter が `navigate` を受信したら、新規 `src/lib/slide-navigation.ts` の helper で次/前ページ番号を算出し、既存の `setPageNumberWithBroadcast(resolvedPage)`（`src/routes/(main)/presenter.tsx:126` 付近）を呼ぶ。このヘルパーは atom 更新と `send-current-page-number` 送信を既にまとめて行うため、新規 effect は不要。
+
+**slide-navigation.ts の API**:
+
+```typescript
+resolveNextPage(config, currentPageNumber): number
+resolvePrevPage(config, currentPageNumber): number
+resolveNextUserSlide(config, currentPageNumber): number  // ArrowDown 相当（オーバーレイグループの次へ）
+resolvePrevUserSlide(config, currentPageNumber): number  // ArrowUp 相当
+resolveFirstSlide(config): number
+resolveLastSlide(config): number
+```
+
+overlay/グループ化を考慮する。現行の navigate ロジックは `src/routes/(main)/presenter.tsx` 内に定義された `getNextPageNumber`/`movePrevSlide`/`moveNextUserSlide`/`movePrevUserSlide` 等のコールバック実装として存在するため、その純粋関数部分をこのファイルへ抽出する（`useSlideShortcut` は callback 受け取り方式を維持、callback 内でヘルパーを呼ぶ形になる）。
+
+### 3. ポインターツール
+
+**新規状態**（`src/lib/pointer-state.ts`）:
+
+```typescript
+toolModeAtom: atom<"none" | "laser" | "pen">("none")
+laserPosAtom: atom<{ x: number; y: number } | null>(null)
+penStrokesAtom: atom<Array<{ id: string; points: Array<{x: number; y: number}> }>>([])
+```
+
+**描画コンポーネント**: `src/components/PointerOverlay.tsx`
+
+- slide 表示領域に `absolute inset-0` で重なる SVG
+- laser: `<circle r=8 fill="#ef4444" opacity=0.7 style={{ mixBlendMode: "multiply" }} />`
+- pen: `<polyline>` per stroke, stroke=#ef4444, strokeWidth=3, strokeLinecap=round, strokeLinejoin=round, fill=none
+- `pointerEvents: "none"`（下の PDF/UI を邪魔しない）
+- props: `toolMode`, `laserPos`, `strokes`, コンテナサイズ（正規化 → ピクセル変換用）
+
+**キーバインド**（presenter/presentation 共通の新規 hook 化 or 各側で重複実装）:
+
+- `L`: `toolMode` を `laser` ↔ `none` トグル
+- `D`: `toolMode` を `pen` ↔ `none` トグル
+- `E`: `pen-clear` 送信（モード問わず実行可能）
+- `Esc`: `toolMode` を `none` へ
+
+トグル時は `tool-mode` broadcast で相手側にも同期。
+
+**ポインター入力**:
+
+- `toolMode === "laser"`: slide 領域で `pointermove` を rAF スロットル → `pointer-move` broadcast + local atom 更新
+- `toolMode === "pen"`:
+  - `pointerdown`: `strokeId = crypto.randomUUID()`, 新規ストロークを local に push + `pen-stroke-start` broadcast
+  - `pointermove`（down 中）: rAF で最新点を local stroke に追加 + `pen-stroke-point` broadcast
+  - `pointerup`: `pen-stroke-end` broadcast
+  - mouse/pen 左ボタンのみ反応。右クリックやホイールは無視
+- `pointerleave` (slide 領域): `pointer-leave` broadcast、local laserPos を null
+
+**rAF スロットル**:
+
+`useRef` で pending 座標を保持、`requestAnimationFrame` 内で最新値を 1 回だけ送る。フレーム内の複数 pointermove は最後の値だけが送信される。
+
+**ペン自動クリア**:
+
+presenter 側の `pageNumberAtom` 変化を検知する effect で `pen-clear` を broadcast + local strokes クリア。
+
+### 4. メニュー抑制
+
+`src/routes/presentation/-Menu.tsx` を修正:
+
+- `toolModeAtom` を購読
+- `toolMode !== "none"` の間は `pointermove` / `pointerdown` リスナーを停止
+- メニューの表示 state を強制的に `false` に
+- 解除時は通常動作に戻る
+
+### 5. アーキテクチャ / ファイル変更
+
+**新規**:
+
+- `src/lib/slide-navigation.ts` — ナビゲーション解決 + 単体テスト
+- `src/lib/slide-navigation.test.ts` — vitest
+- `src/lib/pointer-state.ts` — atoms
+- `src/lib/pointer-state.test.ts` — vitest（純粋 state ロジックのみ）
+- `src/components/PointerOverlay.tsx`
+- `src/broadcast/tools.ts` — ツール系フック `useToolBroadcast`（双方向送受信）
+- `src/routes/presentation/-hooks/use-presentation-shortcut.ts`
+- `src/routes/-hooks/use-tool-shortcut.ts` — `L`/`D`/`E`/`Esc` を両画面共通で処理
+
+**修正**:
+
+- `src/broadcast/types.ts` — 双方向コマンド型を追加
+- `src/broadcast/presenter.ts` — `navigate` 受信 → ナビ解決、ツール系コマンド受信
+- `src/broadcast/presentation.ts` — ツール系コマンド受信、navigate 送信 helper
+- `src/broadcast/index.ts` — 新フックの re-export
+- `src/routes/-hooks/use-slide-shortcut.ts` — ナビゲーションを `slide-navigation.ts` へ委譲、`L`/`D`/`E`/`Esc` は新 `use-tool-shortcut.ts` へ切り出し
+- `src/routes/(main)/-presenter/*` — `PointerOverlay` を PdfPage 上に重ねる配置、ツールフック呼び出し
+- `src/routes/presentation/index.tsx` — `use-presentation-shortcut` 呼び出し、`PointerOverlay` 追加、ツールフック呼び出し
+- `src/routes/presentation/-Menu.tsx` — `toolMode` 購読、suppression
+
+### 6. データフロー
+
+**ページ送り（presentation 起点）**:
+
+```
+presentation: Space 押下
+  → useToolBroadcast (or usePresentationShortcut) が navigate { direction: "next" } を broadcast
+presenter: 受信
+  → resolveNextPage(config, currentPage) で次ページ番号を算出
+  → pageNumberAtom 更新
+  → 既存の「atom → broadcast」effect が send-current-page-number を送信
+presentation: 受信
+  → local pageNumber atom 更新、再レンダリング
+```
+
+**ポインター（レーザー）**:
+
+```
+active 側: pointermove (slide 領域内、toolMode === "laser")
+  → rAF throttle → 正規化座標算出
+  → local laserPosAtom 更新 (即座に自画面に描画)
+  → pointer-move broadcast
+相手側: 受信
+  → laserPosAtom 更新 → PointerOverlay 再描画
+```
+
+**ペン**:
+
+```
+active 側: pointerdown (pen mode)
+  → strokeId = crypto.randomUUID()
+  → local strokes に新規 stroke push
+  → pen-stroke-start broadcast
+  pointermove: local stroke に point 追加 (rAF) + pen-stroke-point broadcast
+  pointerup: pen-stroke-end broadcast
+ページ遷移時: active 側
+  → local strokes クリア
+  → pen-clear broadcast
+相手側: 同じ流れで state 同期
+```
+
+### 7. エラーハンドリング / エッジケース
+
+- **両画面で同時にポインター操作**: 最後の更新が勝つ（`laserPosAtom` は単一値）。実用上同時操作は稀で問題にならない
+- **stroke-start 未到着で stroke-point が先着**: 受信側で strokeId が不明なら新規 stroke を作成して point を追加（順序逆転耐性）
+- **stroke-end が届かない（タブクローズ等）**: stroke は残るが、ページ遷移や `E` で消えるので実害なし
+- **presentation → presenter の navigate 受信失敗**: presenter 側の atom は変化せず、presentation も自身の local state を変えない（presenter がソースオブトゥルース）。BroadcastChannel は同一オリジンの同一ブラウザ内で信頼できる前提
+- **ツールモード解除漏れ**: `Esc` で常時 `none` へ戻せる。メニュー抑制もこれで解除
+- **スライド領域外のポインター**: `pointerleave` で laser を隠す。ペン中は `pointerleave` でストローク終了扱い
+
+### 8. テスト戦略
+
+プロジェクト初のテスト導入。vitest（既に `devDependencies` に設定済みのはずなので確認、無ければ追加）。
+
+**対象**:
+
+1. `slide-navigation.test.ts`
+   - 通常ページの next/prev
+   - pdfpc overlay グループ内でのジャンプ（グループの次の先頭へ飛ぶ）
+   - 先頭で prev / 末尾で next の境界
+   - Home / End
+2. `pointer-state.test.ts`
+   - stroke 追加/終了、clear
+   - tool-mode 遷移、Esc で none へ
+3. （将来）broadcast contract test: コマンド型の round-trip
+
+**CI 追加**: `.github/workflows/ci.yaml` に `pnpm test` と `pnpm tsc -b` ステップを追加（別タスクだが本プランと同時に実施する）。
+
+### 9. 非機能要件
+
+- **パフォーマンス**: pointer-move/pen-stroke-point は rAF スロットル済み。broadcast payload は軽量 (<100 bytes/msg)
+- **アクセシビリティ**: 本設計ではツール起動のための UI ボタンは追加しない（キーボードのみ）。UI 追加は将来の別タスクとし、その時点で `aria-keyshortcuts` 対応を行う
+- **ブラウザ互換**: `crypto.randomUUID` は全モダンブラウザで利用可。`mix-blend-mode` も同様
+
+## リスクと代替案
+
+- **双方向同期の競合**: 片方向（presenter が常にソース）の方が単純。ただしユーザー要望により双方向採用
+- **tool-mode の同期が実質必要か**: 同期しない選択肢もあり（各画面で独立モード）。だが「L を押したら両画面のメニューが消える」など統一挙動が自然なため同期する
+- **ナビゲーション解決を presentation 側でも行う案**: 設定を両側が持つので可能だが、ソースオブトゥルース二重化のリスクがあるため却下。常に presenter が解決
+
+## 完了条件
+
+- [ ] presentation 画面で Space/矢印/PageUp/Down/Home/End でページが進む
+- [ ] `L` でレーザーが両画面に出る、もう一度で消える
+- [ ] `D` でペンが両画面に描画される、ページ遷移で自動クリア、`E` で手動クリア
+- [ ] ツール中は presentation メニューが自動表示されない
+- [ ] `slide-navigation.ts` の単体テストが通る
+- [ ] `pnpm tsc -b` / `pnpm lint` / `pnpm test` が通る

--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -5,7 +5,7 @@ export {
 	getPresentationPairId,
 } from "./pairing";
 export { getPdfData } from "./pdf";
-export { usePresentationBroadcast } from "./presentation";
+export { sendNavigate, usePresentationBroadcast } from "./presentation";
 export { usePresenterBroadcast } from "./presenter";
 export type {
 	BroadcastAction,

--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -7,7 +7,12 @@ export {
 export { getPdfData } from "./pdf";
 export { sendNavigate, usePresentationBroadcast } from "./presentation";
 export { usePresenterBroadcast } from "./presenter";
-export { sendTool, type ToolAction, type ToolSide } from "./tools";
+export {
+	sendTool,
+	type ToolAction,
+	type ToolSide,
+	useToolBroadcast,
+} from "./tools";
 export type {
 	BroadcastAction,
 	PresentationAction,

--- a/src/broadcast/index.ts
+++ b/src/broadcast/index.ts
@@ -7,6 +7,7 @@ export {
 export { getPdfData } from "./pdf";
 export { sendNavigate, usePresentationBroadcast } from "./presentation";
 export { usePresenterBroadcast } from "./presenter";
+export { sendTool, type ToolAction, type ToolSide } from "./tools";
 export type {
 	BroadcastAction,
 	PresentationAction,

--- a/src/broadcast/presentation.ts
+++ b/src/broadcast/presentation.ts
@@ -133,3 +133,16 @@ export function usePresentationBroadcast(
 		};
 	}, [fileName, pairId]);
 }
+
+export function sendNavigate(
+	fileName: string,
+	pairId: string,
+	direction: "next" | "prev" | "home" | "end",
+): void {
+	const channel = getBroadcastChannel(fileName, pairId);
+	channel.postMessage({
+		from: "presentation",
+		command: "navigate",
+		direction,
+	} satisfies PresentationAction);
+}

--- a/src/broadcast/presenter.ts
+++ b/src/broadcast/presenter.ts
@@ -12,6 +12,9 @@ declare global {
 		"get-pdf": EmptyObject;
 		"get-blackout-state": EmptyObject;
 		"get-current-page-number": EmptyObject;
+		navigate: {
+			direction: "next" | "prev" | "home" | "end";
+		};
 	}
 }
 
@@ -22,6 +25,7 @@ export function usePresenterBroadcast(
 	pdf: File,
 	isBlackout: boolean,
 	pageNumber: number,
+	onNavigate?: (direction: "next" | "prev" | "home" | "end") => void,
 ) {
 	const channel = getBroadcastChannel(fileName, pairId);
 	const handleMessage = useEffectEvent(async (action: PresentationAction) => {
@@ -82,6 +86,10 @@ export function usePresenterBroadcast(
 					command: "get-current-page-number-response",
 					pageNumber,
 				} satisfies BroadcastAction);
+				break;
+			case "navigate":
+				console.log("[Presenter Broadcast] Navigate:", action.direction);
+				onNavigate?.(action.direction);
 				break;
 		}
 	});

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -1,6 +1,20 @@
+import { useSetAtom } from "jotai";
+import { useEffect, useEffectEvent } from "react";
 import type { ToolMode } from "#src/lib/pointer-state.ts";
+import {
+	addPenPoint,
+	addPenStroke,
+	clearPenStrokes,
+	endPenStroke,
+	laserPosAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
 import { getBroadcastChannel } from "./channel";
-import type { PresentationAction, PresenterAction } from "./types";
+import type {
+	BroadcastAction,
+	PresentationAction,
+	PresenterAction,
+} from "./types";
 
 // 双方向コマンド: 両方のマップに宣言することで from 問わず送信可能に
 declare global {
@@ -60,3 +74,79 @@ export type ToolAction = Extract<
 			| "pen-clear";
 	}
 >;
+
+/**
+ * ツール系コマンドを受信して pointer-state atoms を更新する。
+ * 自身が送信したメッセージは BroadcastChannel の仕様により受信されないため、
+ * 送信側は別途 local atom を更新すること。
+ */
+export function useToolBroadcast(
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const setToolMode = useSetAtom(toolModeAtom);
+	const setLaserPos = useSetAtom(laserPosAtom);
+	const doAddPenStroke = useSetAtom(addPenStroke);
+	const doAddPenPoint = useSetAtom(addPenPoint);
+	const doEndPenStroke = useSetAtom(endPenStroke);
+	const doClearStrokes = useSetAtom(clearPenStrokes);
+
+	const onAction = useEffectEvent((action: ToolAction) => {
+		switch (action.command) {
+			case "tool-mode":
+				setToolMode(action.mode);
+				break;
+			case "pointer-move":
+				setLaserPos({ x: action.x, y: action.y });
+				break;
+			case "pointer-leave":
+				setLaserPos(null);
+				break;
+			case "pen-stroke-start":
+				doAddPenStroke({
+					strokeId: action.strokeId,
+					x: action.x,
+					y: action.y,
+				});
+				break;
+			case "pen-stroke-point":
+				doAddPenPoint({
+					strokeId: action.strokeId,
+					x: action.x,
+					y: action.y,
+				});
+				break;
+			case "pen-stroke-end":
+				doEndPenStroke({ strokeId: action.strokeId });
+				break;
+			case "pen-clear":
+				doClearStrokes();
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const channel = getBroadcastChannel(fileName, pairId);
+		const abortController = new AbortController();
+		const listener = (event: MessageEvent) => {
+			const action = event.data as BroadcastAction;
+			if (action.from === selfSide) return;
+			if (
+				action.command === "tool-mode" ||
+				action.command === "pointer-move" ||
+				action.command === "pointer-leave" ||
+				action.command === "pen-stroke-start" ||
+				action.command === "pen-stroke-point" ||
+				action.command === "pen-stroke-end" ||
+				action.command === "pen-clear"
+			) {
+				onAction(action as ToolAction);
+			}
+		};
+		channel.addEventListener("message", listener, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, [fileName, pairId, selfSide]);
+}

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -17,27 +17,30 @@ import type {
 	PresenterAction,
 } from "./types";
 
-// 双方向コマンド: 両方のマップに宣言することで from 問わず送信可能に
-declare global {
-	interface PresenterCommandMap {
-		"tool-mode": { mode: "none" | "laser" | "pen" };
-		"pointer-move": { x: number; y: number };
-		"pointer-leave": EmptyObject;
-		"pen-stroke-start": { strokeId: string; x: number; y: number };
-		"pen-stroke-point": { strokeId: string; x: number; y: number };
-		"pen-stroke-end": { strokeId: string };
-		"pen-clear": EmptyObject;
-	}
-	interface PresentationCommandMap {
-		"tool-mode": { mode: "none" | "laser" | "pen" };
-		"pointer-move": { x: number; y: number };
-		"pointer-leave": EmptyObject;
-		"pen-stroke-start": { strokeId: string; x: number; y: number };
-		"pen-stroke-point": { strokeId: string; x: number; y: number };
-		"pen-stroke-end": { strokeId: string };
-		"pen-clear": EmptyObject;
-	}
+interface ToolCommandMap {
+	"tool-mode": { mode: ToolMode };
+	"pointer-move": { x: number; y: number };
+	"pointer-leave": EmptyObject;
+	"pen-stroke-start": { strokeId: string; x: number; y: number };
+	"pen-stroke-point": { strokeId: string; x: number; y: number };
+	"pen-stroke-end": { strokeId: string };
+	"pen-clear": EmptyObject;
 }
+
+declare global {
+	interface PresenterCommandMap extends ToolCommandMap {}
+	interface PresentationCommandMap extends ToolCommandMap {}
+}
+
+const TOOL_COMMAND_NAMES = new Set<string>([
+	"tool-mode",
+	"pointer-move",
+	"pointer-leave",
+	"pen-stroke-start",
+	"pen-stroke-point",
+	"pen-stroke-end",
+	"pen-clear",
+]);
 
 export type ToolSide = "presenter" | "presentation";
 
@@ -66,22 +69,13 @@ export function sendTool(
 
 export type ToolAction = Extract<
 	PresenterAction | PresentationAction,
-	{
-		command:
-			| "tool-mode"
-			| "pointer-move"
-			| "pointer-leave"
-			| "pen-stroke-start"
-			| "pen-stroke-point"
-			| "pen-stroke-end"
-			| "pen-clear";
-	}
+	{ command: keyof ToolCommandMap }
 >;
 
 /**
  * ツール系コマンドを受信して pointer-state atoms を更新する。
- * 自身が送信したメッセージは BroadcastChannel の仕様により受信されないため、
- * 送信側は別途 local atom を更新すること。
+ * BroadcastChannel の仕様により自身が送信したメッセージは届かないが、
+ * 念のため selfSide チェックで二重防御する。
  */
 export function useToolBroadcast(
 	fileName: string,
@@ -135,15 +129,7 @@ export function useToolBroadcast(
 		const listener = (event: MessageEvent) => {
 			const action = event.data as BroadcastAction;
 			if (action.from === selfSide) return;
-			if (
-				action.command === "tool-mode" ||
-				action.command === "pointer-move" ||
-				action.command === "pointer-leave" ||
-				action.command === "pen-stroke-start" ||
-				action.command === "pen-stroke-point" ||
-				action.command === "pen-stroke-end" ||
-				action.command === "pen-clear"
-			) {
+			if (TOOL_COMMAND_NAMES.has(action.command)) {
 				onAction(action as ToolAction);
 			}
 		};

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -1,5 +1,6 @@
 import { useSetAtom } from "jotai";
 import { useEffect, useEffectEvent } from "react";
+import type { EmptyObject } from "type-fest";
 import type { ToolMode } from "#src/lib/pointer-state.ts";
 import {
 	addPenPoint,
@@ -21,20 +22,20 @@ declare global {
 	interface PresenterCommandMap {
 		"tool-mode": { mode: "none" | "laser" | "pen" };
 		"pointer-move": { x: number; y: number };
-		"pointer-leave": Record<string, never>;
+		"pointer-leave": EmptyObject;
 		"pen-stroke-start": { strokeId: string; x: number; y: number };
 		"pen-stroke-point": { strokeId: string; x: number; y: number };
 		"pen-stroke-end": { strokeId: string };
-		"pen-clear": Record<string, never>;
+		"pen-clear": EmptyObject;
 	}
 	interface PresentationCommandMap {
 		"tool-mode": { mode: "none" | "laser" | "pen" };
 		"pointer-move": { x: number; y: number };
-		"pointer-leave": Record<string, never>;
+		"pointer-leave": EmptyObject;
 		"pen-stroke-start": { strokeId: string; x: number; y: number };
 		"pen-stroke-point": { strokeId: string; x: number; y: number };
 		"pen-stroke-end": { strokeId: string };
-		"pen-clear": Record<string, never>;
+		"pen-clear": EmptyObject;
 	}
 }
 
@@ -56,9 +57,11 @@ export function sendTool(
 	cmd: ToolCommand,
 ): void {
 	const channel = getBroadcastChannel(fileName, pairId);
-	// postMessage は any を受け付けるため厳密な satisfies は不要。
-	// 型安全性は呼び出し側の引数型 (ToolCommand, ToolSide) で担保される
-	channel.postMessage({ from, ...cmd });
+	if (from === "presenter") {
+		channel.postMessage({ from, ...cmd } satisfies PresenterAction);
+	} else {
+		channel.postMessage({ from, ...cmd } satisfies PresentationAction);
+	}
 }
 
 export type ToolAction = Extract<

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -92,6 +92,8 @@ export function useToolBroadcast(
 	const onAction = useEffectEvent((action: ToolAction) => {
 		switch (action.command) {
 			case "tool-mode":
+				// 前モードのレーザー残像を避けるため、切替時は位置をリセット
+				setLaserPos(null);
 				setToolMode(action.mode);
 				break;
 			case "pointer-move":

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -32,7 +32,7 @@ declare global {
 	interface PresentationCommandMap extends ToolCommandMap {}
 }
 
-const TOOL_COMMAND_NAMES = new Set<string>([
+const TOOL_COMMAND_NAMES: ReadonlySet<string> = new Set([
 	"tool-mode",
 	"pointer-move",
 	"pointer-leave",
@@ -40,7 +40,7 @@ const TOOL_COMMAND_NAMES = new Set<string>([
 	"pen-stroke-point",
 	"pen-stroke-end",
 	"pen-clear",
-]);
+] satisfies (keyof ToolCommandMap)[]);
 
 export type ToolSide = "presenter" | "presentation";
 

--- a/src/broadcast/tools.ts
+++ b/src/broadcast/tools.ts
@@ -1,0 +1,62 @@
+import type { ToolMode } from "#src/lib/pointer-state.ts";
+import { getBroadcastChannel } from "./channel";
+import type { PresentationAction, PresenterAction } from "./types";
+
+// 双方向コマンド: 両方のマップに宣言することで from 問わず送信可能に
+declare global {
+	interface PresenterCommandMap {
+		"tool-mode": { mode: "none" | "laser" | "pen" };
+		"pointer-move": { x: number; y: number };
+		"pointer-leave": Record<string, never>;
+		"pen-stroke-start": { strokeId: string; x: number; y: number };
+		"pen-stroke-point": { strokeId: string; x: number; y: number };
+		"pen-stroke-end": { strokeId: string };
+		"pen-clear": Record<string, never>;
+	}
+	interface PresentationCommandMap {
+		"tool-mode": { mode: "none" | "laser" | "pen" };
+		"pointer-move": { x: number; y: number };
+		"pointer-leave": Record<string, never>;
+		"pen-stroke-start": { strokeId: string; x: number; y: number };
+		"pen-stroke-point": { strokeId: string; x: number; y: number };
+		"pen-stroke-end": { strokeId: string };
+		"pen-clear": Record<string, never>;
+	}
+}
+
+export type ToolSide = "presenter" | "presentation";
+
+type ToolCommand =
+	| { command: "tool-mode"; mode: ToolMode }
+	| { command: "pointer-move"; x: number; y: number }
+	| { command: "pointer-leave" }
+	| { command: "pen-stroke-start"; strokeId: string; x: number; y: number }
+	| { command: "pen-stroke-point"; strokeId: string; x: number; y: number }
+	| { command: "pen-stroke-end"; strokeId: string }
+	| { command: "pen-clear" };
+
+export function sendTool(
+	fileName: string,
+	pairId: string,
+	from: ToolSide,
+	cmd: ToolCommand,
+): void {
+	const channel = getBroadcastChannel(fileName, pairId);
+	// postMessage は any を受け付けるため厳密な satisfies は不要。
+	// 型安全性は呼び出し側の引数型 (ToolCommand, ToolSide) で担保される
+	channel.postMessage({ from, ...cmd });
+}
+
+export type ToolAction = Extract<
+	PresenterAction | PresentationAction,
+	{
+		command:
+			| "tool-mode"
+			| "pointer-move"
+			| "pointer-leave"
+			| "pen-stroke-start"
+			| "pen-stroke-point"
+			| "pen-stroke-end"
+			| "pen-clear";
+	}
+>;

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -1,6 +1,8 @@
 import { useAtomValue } from "jotai";
+import { memo } from "react";
 import {
 	laserPosAtom,
+	type PenStroke,
 	penStrokesAtom,
 	toolModeAtom,
 } from "#src/lib/pointer-state.ts";
@@ -12,6 +14,21 @@ interface PointerOverlayProps {
 
 const PEN_COLOR = "#ef4444";
 const PEN_WIDTH = 0.004;
+
+const Stroke = memo(function Stroke({ stroke }: { stroke: PenStroke }) {
+	if (stroke.points.length === 0) return null;
+	return (
+		<polyline
+			points={stroke.points.map((p) => `${p.x},${p.y}`).join(" ")}
+			fill="none"
+			stroke={PEN_COLOR}
+			strokeWidth={PEN_WIDTH}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			vectorEffect="non-scaling-stroke"
+		/>
+	);
+});
 
 export function PointerOverlay({ className }: PointerOverlayProps) {
 	const toolMode = useAtomValue(toolModeAtom);
@@ -27,20 +44,9 @@ export function PointerOverlay({ className }: PointerOverlayProps) {
 			preserveAspectRatio="none"
 			aria-hidden="true"
 		>
-			{strokes.map((stroke) =>
-				stroke.points.length === 0 ? null : (
-					<polyline
-						key={stroke.id}
-						points={stroke.points.map((p) => `${p.x},${p.y}`).join(" ")}
-						fill="none"
-						stroke={PEN_COLOR}
-						strokeWidth={PEN_WIDTH}
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						vectorEffect="non-scaling-stroke"
-					/>
-				),
-			)}
+			{strokes.map((stroke) => (
+				<Stroke key={stroke.id} stroke={stroke} />
+			))}
 			{toolMode === "laser" && laserPos !== null ? (
 				<circle
 					cx={laserPos.x}

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -13,7 +13,8 @@ interface PointerOverlayProps {
 }
 
 const PEN_COLOR = "#ef4444";
-const PEN_WIDTH = 0.004;
+// vectorEffect="non-scaling-stroke" は strokeWidth を CSS pixel で解釈するため px 値で指定する
+const PEN_WIDTH_PX = 3;
 
 const Stroke = memo(function Stroke({ stroke }: { stroke: PenStroke }) {
 	if (stroke.points.length === 0) return null;
@@ -22,7 +23,7 @@ const Stroke = memo(function Stroke({ stroke }: { stroke: PenStroke }) {
 			points={stroke.points.map((p) => `${p.x},${p.y}`).join(" ")}
 			fill="none"
 			stroke={PEN_COLOR}
-			strokeWidth={PEN_WIDTH}
+			strokeWidth={PEN_WIDTH_PX}
 			strokeLinecap="round"
 			strokeLinejoin="round"
 			vectorEffect="non-scaling-stroke"

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -1,0 +1,56 @@
+import { useAtomValue } from "jotai";
+import {
+	laserPosAtom,
+	penStrokesAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+import { cn } from "#src/lib/utils.ts";
+
+interface PointerOverlayProps {
+	className?: string;
+}
+
+const PEN_COLOR = "#ef4444";
+const PEN_WIDTH = 0.004;
+
+export function PointerOverlay({ className }: PointerOverlayProps) {
+	const toolMode = useAtomValue(toolModeAtom);
+	const laserPos = useAtomValue(laserPosAtom);
+	const strokes = useAtomValue(penStrokesAtom);
+
+	if (toolMode === "none" && strokes.length === 0) return null;
+
+	return (
+		<svg
+			className={cn("absolute inset-0 pointer-events-none", className)}
+			viewBox="0 0 1 1"
+			preserveAspectRatio="none"
+			aria-hidden="true"
+		>
+			{strokes.map((stroke) =>
+				stroke.points.length === 0 ? null : (
+					<polyline
+						key={stroke.id}
+						points={stroke.points.map((p) => `${p.x},${p.y}`).join(" ")}
+						fill="none"
+						stroke={PEN_COLOR}
+						strokeWidth={PEN_WIDTH}
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						vectorEffect="non-scaling-stroke"
+					/>
+				),
+			)}
+			{toolMode === "laser" && laserPos !== null ? (
+				<circle
+					cx={laserPos.x}
+					cy={laserPos.y}
+					r={0.008}
+					fill={PEN_COLOR}
+					opacity={0.8}
+					style={{ mixBlendMode: "multiply" }}
+				/>
+			) : null}
+		</svg>
+	);
+}

--- a/src/lib/navigation-utils.test.ts
+++ b/src/lib/navigation-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampPageNumber,
+	getNextUserSlidePageNumber,
+	getPrevUserSlidePageNumber,
+	resolveFirstSlide,
+	resolveLastSlide,
+	resolveNextPage,
+	resolvePrevPage,
+} from "./navigation-utils.ts";
+import type { ResolvedPdfpcConfigV2 } from "./pdfpc-config.ts";
+
+const makeConfig = (
+	pages: number[][],
+): Pick<ResolvedPdfpcConfigV2, "pages" | "totalOverlays"> => ({
+	pages: pages.map((group) =>
+		group.map((pageNumber) => ({
+			pageNumber,
+			label: String(pageNumber),
+			overlay: 0,
+			note: "",
+		})),
+	) as ResolvedPdfpcConfigV2["pages"],
+	totalOverlays: pages.flat().length,
+});
+
+describe("clampPageNumber", () => {
+	it("最小1", () => expect(clampPageNumber(0, 10)).toBe(1));
+	it("最大 max", () => expect(clampPageNumber(99, 10)).toBe(10));
+	it("範囲内はそのまま", () => expect(clampPageNumber(5, 10)).toBe(5));
+});
+
+describe("resolveNextPage", () => {
+	it("通常は +1", () => expect(resolveNextPage(5, 10)).toBe(6));
+	it("末尾では同値", () => expect(resolveNextPage(10, 10)).toBe(10));
+});
+
+describe("resolvePrevPage", () => {
+	it("通常は -1", () => expect(resolvePrevPage(5, 10)).toBe(4));
+	it("先頭では 1", () => expect(resolvePrevPage(1, 10)).toBe(1));
+});
+
+describe("resolveFirstSlide / resolveLastSlide", () => {
+	it("first は 1", () => expect(resolveFirstSlide()).toBe(1));
+	it("last は totalOverlays", () => expect(resolveLastSlide(10)).toBe(10));
+});
+
+describe("getNextUserSlidePageNumber", () => {
+	const { pages } = makeConfig([[1, 2], [3], [4, 5, 6]]);
+	it("グループ内から次グループ先頭へ", () =>
+		expect(getNextUserSlidePageNumber(pages, 1)).toBe(3));
+	it("中央からでも次グループ先頭へ", () =>
+		expect(getNextUserSlidePageNumber(pages, 2)).toBe(3));
+	it("最後のグループでは null", () =>
+		expect(getNextUserSlidePageNumber(pages, 5)).toBe(null));
+});
+
+describe("getPrevUserSlidePageNumber", () => {
+	const { pages } = makeConfig([[1, 2], [3], [4, 5, 6]]);
+	it("グループ内から前グループ先頭へ", () =>
+		expect(getPrevUserSlidePageNumber(pages, 5)).toBe(3));
+	it("最初のグループでは null", () =>
+		expect(getPrevUserSlidePageNumber(pages, 1)).toBe(null));
+});

--- a/src/lib/navigation-utils.ts
+++ b/src/lib/navigation-utils.ts
@@ -58,3 +58,37 @@ export function clampPageNumber(
 ): number {
 	return Math.max(1, Math.min(pageNumber, maxPageNumber));
 }
+
+/**
+ * 次のページ番号を解決する（単純 +1、末尾クランプ）
+ */
+export function resolveNextPage(
+	currentPageNumber: number,
+	totalOverlays: number,
+): number {
+	return clampPageNumber(currentPageNumber + 1, totalOverlays);
+}
+
+/**
+ * 前のページ番号を解決する（単純 -1、先頭クランプ）
+ */
+export function resolvePrevPage(
+	currentPageNumber: number,
+	totalOverlays: number,
+): number {
+	return clampPageNumber(currentPageNumber - 1, totalOverlays);
+}
+
+/**
+ * 最初のページ番号
+ */
+export function resolveFirstSlide(): number {
+	return 1;
+}
+
+/**
+ * 最後のページ番号
+ */
+export function resolveLastSlide(totalOverlays: number): number {
+	return totalOverlays;
+}

--- a/src/lib/pointer-state.test.ts
+++ b/src/lib/pointer-state.test.ts
@@ -1,0 +1,76 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+import {
+	addPenPoint,
+	addPenStroke,
+	clearPenStrokes,
+	endPenStroke,
+	laserPosAtom,
+	penStrokesAtom,
+	toolModeAtom,
+} from "./pointer-state.ts";
+
+describe("toolModeAtom", () => {
+	it("初期値は none", () => {
+		const store = createStore();
+		expect(store.get(toolModeAtom)).toBe("none");
+	});
+	it("laser/pen/none に切り替えできる", () => {
+		const store = createStore();
+		store.set(toolModeAtom, "laser");
+		expect(store.get(toolModeAtom)).toBe("laser");
+		store.set(toolModeAtom, "pen");
+		expect(store.get(toolModeAtom)).toBe("pen");
+		store.set(toolModeAtom, "none");
+		expect(store.get(toolModeAtom)).toBe("none");
+	});
+});
+
+describe("laserPosAtom", () => {
+	it("初期値は null", () => {
+		const store = createStore();
+		expect(store.get(laserPosAtom)).toBe(null);
+	});
+});
+
+describe("penStrokes 操作", () => {
+	it("addPenStroke で新規ストローク追加", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0.1, y: 0.2 });
+		expect(store.get(penStrokesAtom)).toEqual([
+			{ id: "s1", points: [{ x: 0.1, y: 0.2 }], ended: false },
+		]);
+	});
+
+	it("addPenPoint で既存ストロークに点追加", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0.1, y: 0.2 });
+		store.set(addPenPoint, { strokeId: "s1", x: 0.3, y: 0.4 });
+		expect(store.get(penStrokesAtom)[0].points).toEqual([
+			{ x: 0.1, y: 0.2 },
+			{ x: 0.3, y: 0.4 },
+		]);
+	});
+
+	it("addPenPoint で未知の strokeId ならストロークを自動作成", () => {
+		const store = createStore();
+		store.set(addPenPoint, { strokeId: "s_new", x: 0.5, y: 0.5 });
+		expect(store.get(penStrokesAtom)).toEqual([
+			{ id: "s_new", points: [{ x: 0.5, y: 0.5 }], ended: false },
+		]);
+	});
+
+	it("endPenStroke で ended=true", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0, y: 0 });
+		store.set(endPenStroke, { strokeId: "s1" });
+		expect(store.get(penStrokesAtom)[0].ended).toBe(true);
+	});
+
+	it("clearPenStrokes で空", () => {
+		const store = createStore();
+		store.set(addPenStroke, { strokeId: "s1", x: 0, y: 0 });
+		store.set(clearPenStrokes);
+		expect(store.get(penStrokesAtom)).toEqual([]);
+	});
+});

--- a/src/lib/pointer-state.ts
+++ b/src/lib/pointer-state.ts
@@ -1,0 +1,78 @@
+import { atom } from "jotai";
+
+export type ToolMode = "none" | "laser" | "pen";
+
+export interface NormalizedPoint {
+	x: number;
+	y: number;
+}
+
+export interface PenStroke {
+	id: string;
+	points: NormalizedPoint[];
+	ended: boolean;
+}
+
+export const toolModeAtom = atom<ToolMode>("none");
+export const laserPosAtom = atom<NormalizedPoint | null>(null);
+export const penStrokesAtom = atom<PenStroke[]>([]);
+
+export const addPenStroke = atom(
+	null,
+	(get, set, payload: { strokeId: string; x: number; y: number }) => {
+		const strokes = get(penStrokesAtom);
+		if (strokes.some((s) => s.id === payload.strokeId)) return;
+		set(penStrokesAtom, [
+			...strokes,
+			{
+				id: payload.strokeId,
+				points: [{ x: payload.x, y: payload.y }],
+				ended: false,
+			},
+		]);
+	},
+);
+
+export const addPenPoint = atom(
+	null,
+	(get, set, payload: { strokeId: string; x: number; y: number }) => {
+		const strokes = get(penStrokesAtom);
+		const existing = strokes.find((s) => s.id === payload.strokeId);
+		if (!existing) {
+			set(penStrokesAtom, [
+				...strokes,
+				{
+					id: payload.strokeId,
+					points: [{ x: payload.x, y: payload.y }],
+					ended: false,
+				},
+			]);
+			return;
+		}
+		set(
+			penStrokesAtom,
+			strokes.map((s) =>
+				s.id === payload.strokeId
+					? { ...s, points: [...s.points, { x: payload.x, y: payload.y }] }
+					: s,
+			),
+		);
+	},
+);
+
+export const endPenStroke = atom(
+	null,
+	(get, set, payload: { strokeId: string }) => {
+		const strokes = get(penStrokesAtom);
+		set(
+			penStrokesAtom,
+			strokes.map((s) =>
+				s.id === payload.strokeId ? { ...s, ended: true } : s,
+			),
+		);
+	},
+);
+
+export const clearPenStrokes = atom(null, (_get, set) => {
+	set(penStrokesAtom, []);
+});

--- a/src/lib/pointer-state.ts
+++ b/src/lib/pointer-state.ts
@@ -37,16 +37,8 @@ export const addPenPoint = atom(
 	null,
 	(get, set, payload: { strokeId: string; x: number; y: number }) => {
 		const strokes = get(penStrokesAtom);
-		const existing = strokes.find((s) => s.id === payload.strokeId);
-		if (!existing) {
-			set(penStrokesAtom, [
-				...strokes,
-				{
-					id: payload.strokeId,
-					points: [{ x: payload.x, y: payload.y }],
-					ended: false,
-				},
-			]);
+		if (!strokes.some((s) => s.id === payload.strokeId)) {
+			set(addPenStroke, payload);
 			return;
 		}
 		set(
@@ -73,6 +65,7 @@ export const endPenStroke = atom(
 	},
 );
 
-export const clearPenStrokes = atom(null, (_get, set) => {
+export const clearPenStrokes = atom(null, (get, set) => {
+	if (get(penStrokesAtom).length === 0) return;
 	set(penStrokesAtom, []);
 });

--- a/src/routes/(main)/-presenter/SlideStage.tsx
+++ b/src/routes/(main)/-presenter/SlideStage.tsx
@@ -1,6 +1,6 @@
 import type { ClassValue } from "clsx";
 import type { PDFDocumentProxy } from "pdfjs-dist";
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 import { PdfPage } from "#src/components/PdfPage.tsx";
 import { cn } from "#src/lib/utils.ts";
 
@@ -9,11 +9,13 @@ export const SlideStage = function SlideStage({
 	pageNumber,
 	className,
 	ref,
+	children,
 }: {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	className?: ClassValue;
 	ref?: RefObject<HTMLElement | null>;
+	children?: ReactNode;
 }) {
 	return (
 		<section className={cn("relative", className)} ref={ref}>
@@ -22,6 +24,7 @@ export const SlideStage = function SlideStage({
 				pageNumber={pageNumber}
 				className="absolute inset-0"
 			/>
+			{children}
 		</section>
 	);
 };

--- a/src/routes/(main)/presenter.tsx
+++ b/src/routes/(main)/presenter.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { GlobalWorkerOptions } from "pdfjs-dist";
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 import {
 	Suspense,
 	startTransition,
 	useCallback,
+	useEffect,
 	useRef,
 	useState,
 } from "react";
@@ -14,9 +15,12 @@ import {
 	type BroadcastAction,
 	ensurePresenterPairId,
 	getBroadcastChannel,
+	sendTool,
 	usePresenterBroadcast,
+	useToolBroadcast,
 } from "#src/broadcast";
 import { OverviewDialog } from "#src/components/OverviewDialog";
+import { PointerOverlay } from "#src/components/PointerOverlay.tsx";
 import { Button } from "#src/components/ui/button";
 import { Skeleton } from "#src/components/ui/skeleton.tsx";
 import {
@@ -24,7 +28,10 @@ import {
 	getNextUserSlidePageNumber,
 	getPrevUserSlidePageNumber,
 } from "#src/lib/navigation-utils.ts";
+import { clearPenStrokes } from "#src/lib/pointer-state.ts";
+import { usePointerEmitter } from "../-hooks/use-pointer-emitter";
 import { useSlideShortcut } from "../-hooks/use-slide-shortcut";
+import { useToolShortcut } from "../-hooks/use-tool-shortcut";
 import { ModeForm } from "./-presenter/ModeForm";
 import { NextPrevFooter } from "./-presenter/NextPrevFooter";
 import { NextSlide } from "./-presenter/NextSlide";
@@ -295,6 +302,18 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 		handleNavigate,
 	);
 
+	useToolBroadcast(fileName, pairId, "presenter");
+	useToolShortcut(fileName, pairId, "presenter");
+	usePointerEmitter(slideStageRef, fileName, pairId, "presenter");
+
+	// ページ遷移時にペンストロークを自動クリア
+	const doClearStrokes = useSetAtom(clearPenStrokes);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: pageNumber の変化をトリガーとして意図的に依存配列に含める
+	useEffect(() => {
+		doClearStrokes();
+		sendTool(fileName, pairId, "presenter", { command: "pen-clear" });
+	}, [pageNumber, fileName, pairId, doClearStrokes]);
+
 	return (
 		<>
 			<div className="grid h-full max-h-full grid-cols-[minmax(0,1fr)_clamp(280px,28vw,420px)] grid-rows-[3fr_1fr] p-4 gap-4">
@@ -303,7 +322,9 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 					pageNumber={pageNumber}
 					className="aspect-video h-full max-w-full place-self-center"
 					ref={slideStageRef}
-				/>
+				>
+					<PointerOverlay />
+				</SlideStage>
 				<div className="row-span-2 flex flex-col gap-4">
 					<NextSlide
 						currentSlidePage={pageNumber}

--- a/src/routes/(main)/presenter.tsx
+++ b/src/routes/(main)/presenter.tsx
@@ -306,10 +306,12 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 	useToolShortcut(fileName, pairId, "presenter");
 	usePointerEmitter(slideStageRef, fileName, pairId, "presenter");
 
-	// ページ遷移時にペンストロークを自動クリア
+	// ページ遷移時にペンストロークを自動クリア（初回マウント時の無駄な broadcast は避ける）
 	const doClearStrokes = useSetAtom(clearPenStrokes);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: pageNumber の変化をトリガーとして意図的に依存配列に含める
+	const prevPageNumberRef = useRef(pageNumber);
 	useEffect(() => {
+		if (prevPageNumberRef.current === pageNumber) return;
+		prevPageNumberRef.current = pageNumber;
 		doClearStrokes();
 		sendTool(fileName, pairId, "presenter", { command: "pen-clear" });
 	}, [pageNumber, fileName, pairId, doClearStrokes]);

--- a/src/routes/(main)/presenter.tsx
+++ b/src/routes/(main)/presenter.tsx
@@ -264,6 +264,27 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 		[slideStageRef, nextSlideRef, nextPrevRef],
 	);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: nextSlide 等は毎レンダーで作り直される
+	const handleNavigate = useCallback(
+		(direction: "next" | "prev" | "home" | "end") => {
+			switch (direction) {
+				case "next":
+					nextSlide();
+					break;
+				case "prev":
+					prevSlide();
+					break;
+				case "home":
+					jumpToFirstSlide();
+					break;
+				case "end":
+					jumpToLastSlide();
+					break;
+			}
+		},
+		[pageNumber, pdfpcConfig.totalOverlays],
+	);
+
 	usePresenterBroadcast(
 		fileName,
 		pairId,
@@ -271,6 +292,7 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 		pdf,
 		isBlackout,
 		pageNumber,
+		handleNavigate,
 	);
 
 	return (

--- a/src/routes/-hooks/use-pointer-emitter.ts
+++ b/src/routes/-hooks/use-pointer-emitter.ts
@@ -9,6 +9,23 @@ import {
 	toolModeAtom,
 } from "#src/lib/pointer-state.ts";
 
+function normalizedPointer(
+	event: PointerEvent,
+	el: HTMLElement,
+): { x: number; y: number } {
+	const rect = el.getBoundingClientRect();
+	return {
+		x: Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width)),
+		y: Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height)),
+	};
+}
+
+function newStrokeId(): string {
+	return typeof crypto.randomUUID === "function"
+		? crypto.randomUUID()
+		: `stroke-${Date.now()}-${Math.random()}`;
+}
+
 /**
  * 指定要素内でのマウス移動/クリックを観察し、tool-mode に応じて
  * ローカルの pointer-state を更新 + broadcast する。
@@ -31,7 +48,6 @@ export function usePointerEmitter(
 	const pendingPointRef = useRef<{ x: number; y: number } | null>(null);
 	const rafHandleRef = useRef<number | null>(null);
 
-	// useEffectEvent: 最新の toolMode/atoms/props を参照しつつ安定参照を保つ
 	const flushPendingPoint = useEffectEvent(() => {
 		rafHandleRef.current = null;
 		const p = pendingPointRef.current;
@@ -56,8 +72,10 @@ export function usePointerEmitter(
 		}
 	});
 
-	const schedule = useEffectEvent((p: { x: number; y: number }) => {
-		pendingPointRef.current = p;
+	const handleMove = useEffectEvent((event: PointerEvent) => {
+		const el = containerRef.current;
+		if (!el) return;
+		pendingPointRef.current = normalizedPointer(event, el);
 		if (rafHandleRef.current !== null) return;
 		rafHandleRef.current = requestAnimationFrame(flushPendingPoint);
 	});
@@ -70,23 +88,14 @@ export function usePointerEmitter(
 		}
 	});
 
-	const handleDown = useEffectEvent((event: PointerEvent, el: HTMLElement) => {
+	const handleDown = useEffectEvent((event: PointerEvent) => {
 		if (toolMode !== "pen") return;
 		if (event.button !== 0) return;
+		const el = containerRef.current;
+		if (!el) return;
 		event.preventDefault();
-		const rect = el.getBoundingClientRect();
-		const x = Math.max(
-			0,
-			Math.min(1, (event.clientX - rect.left) / rect.width),
-		);
-		const y = Math.max(
-			0,
-			Math.min(1, (event.clientY - rect.top) / rect.height),
-		);
-		const strokeId =
-			typeof crypto.randomUUID === "function"
-				? crypto.randomUUID()
-				: `stroke-${Date.now()}-${Math.random()}`;
+		const { x, y } = normalizedPointer(event, el);
+		const strokeId = newStrokeId();
 		strokeIdRef.current = strokeId;
 		doAddPenStroke({ strokeId, x, y });
 		sendTool(fileName, pairId, selfSide, {
@@ -116,42 +125,13 @@ export function usePointerEmitter(
 		if (toolMode === "none") return;
 
 		const abortController = new AbortController();
+		const signal = abortController.signal;
 
-		const toNormalized = (event: PointerEvent): { x: number; y: number } => {
-			const rect = el.getBoundingClientRect();
-			const x = (event.clientX - rect.left) / rect.width;
-			const y = (event.clientY - rect.top) / rect.height;
-			return {
-				x: Math.max(0, Math.min(1, x)),
-				y: Math.max(0, Math.min(1, y)),
-			};
-		};
-
-		el.addEventListener(
-			"pointermove",
-			(event: PointerEvent) => schedule(toNormalized(event)),
-			{ signal: abortController.signal },
-		);
-		el.addEventListener("pointerleave", () => handleLeave(), {
-			signal: abortController.signal,
-		});
-		el.addEventListener(
-			"pointerdown",
-			(event: PointerEvent) => handleDown(event, el),
-			{
-				signal: abortController.signal,
-			},
-		);
-		el.addEventListener("pointerup", (event: PointerEvent) => handleUp(event), {
-			signal: abortController.signal,
-		});
-		el.addEventListener(
-			"pointercancel",
-			(event: PointerEvent) => handleUp(event),
-			{
-				signal: abortController.signal,
-			},
-		);
+		el.addEventListener("pointermove", handleMove, { signal });
+		el.addEventListener("pointerleave", handleLeave, { signal });
+		el.addEventListener("pointerdown", handleDown, { signal });
+		el.addEventListener("pointerup", handleUp, { signal });
+		el.addEventListener("pointercancel", handleUp, { signal });
 
 		return () => {
 			abortController.abort();

--- a/src/routes/-hooks/use-pointer-emitter.ts
+++ b/src/routes/-hooks/use-pointer-emitter.ts
@@ -12,18 +12,13 @@ import {
 function normalizedPointer(
 	event: PointerEvent,
 	el: HTMLElement,
-): { x: number; y: number } {
+): { x: number; y: number } | null {
 	const rect = el.getBoundingClientRect();
+	if (rect.width === 0 || rect.height === 0) return null;
 	return {
 		x: Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width)),
 		y: Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height)),
 	};
-}
-
-function newStrokeId(): string {
-	return typeof crypto.randomUUID === "function"
-		? crypto.randomUUID()
-		: `stroke-${Date.now()}-${Math.random()}`;
 }
 
 /**
@@ -73,9 +68,13 @@ export function usePointerEmitter(
 	});
 
 	const handleMove = useEffectEvent((event: PointerEvent) => {
+		// ペンモード中、未 down の間は rAF スケジュールしない
+		if (toolMode === "pen" && !strokeIdRef.current) return;
 		const el = containerRef.current;
 		if (!el) return;
-		pendingPointRef.current = normalizedPointer(event, el);
+		const point = normalizedPointer(event, el);
+		if (!point) return;
+		pendingPointRef.current = point;
 		if (rafHandleRef.current !== null) return;
 		rafHandleRef.current = requestAnimationFrame(flushPendingPoint);
 	});
@@ -93,16 +92,17 @@ export function usePointerEmitter(
 		if (event.button !== 0) return;
 		const el = containerRef.current;
 		if (!el) return;
+		const point = normalizedPointer(event, el);
+		if (!point) return;
 		event.preventDefault();
-		const { x, y } = normalizedPointer(event, el);
-		const strokeId = newStrokeId();
+		const strokeId = crypto.randomUUID();
 		strokeIdRef.current = strokeId;
-		doAddPenStroke({ strokeId, x, y });
+		doAddPenStroke({ strokeId, x: point.x, y: point.y });
 		sendTool(fileName, pairId, selfSide, {
 			command: "pen-stroke-start",
 			strokeId,
-			x,
-			y,
+			x: point.x,
+			y: point.y,
 		});
 		(event.target as Element).setPointerCapture?.(event.pointerId);
 	});

--- a/src/routes/-hooks/use-pointer-emitter.ts
+++ b/src/routes/-hooks/use-pointer-emitter.ts
@@ -1,0 +1,164 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import { type RefObject, useEffect, useEffectEvent, useRef } from "react";
+import { sendTool, type ToolSide } from "#src/broadcast";
+import {
+	addPenPoint,
+	addPenStroke,
+	endPenStroke,
+	laserPosAtom,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+
+/**
+ * 指定要素内でのマウス移動/クリックを観察し、tool-mode に応じて
+ * ローカルの pointer-state を更新 + broadcast する。
+ * - laser: pointermove で座標を更新/送信
+ * - pen: pointerdown で新規ストローク、drag 中 pointermove で点追加、pointerup で終了
+ */
+export function usePointerEmitter(
+	containerRef: RefObject<HTMLElement | null>,
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const toolMode = useAtomValue(toolModeAtom);
+	const setLaserPos = useSetAtom(laserPosAtom);
+	const doAddPenStroke = useSetAtom(addPenStroke);
+	const doAddPenPoint = useSetAtom(addPenPoint);
+	const doEndPenStroke = useSetAtom(endPenStroke);
+
+	const strokeIdRef = useRef<string | null>(null);
+	const pendingPointRef = useRef<{ x: number; y: number } | null>(null);
+	const rafHandleRef = useRef<number | null>(null);
+
+	// useEffectEvent: 最新の toolMode/atoms/props を参照しつつ安定参照を保つ
+	const flushPendingPoint = useEffectEvent(() => {
+		rafHandleRef.current = null;
+		const p = pendingPointRef.current;
+		if (!p) return;
+		pendingPointRef.current = null;
+
+		if (toolMode === "laser") {
+			setLaserPos(p);
+			sendTool(fileName, pairId, selfSide, {
+				command: "pointer-move",
+				x: p.x,
+				y: p.y,
+			});
+		} else if (toolMode === "pen" && strokeIdRef.current) {
+			doAddPenPoint({ strokeId: strokeIdRef.current, x: p.x, y: p.y });
+			sendTool(fileName, pairId, selfSide, {
+				command: "pen-stroke-point",
+				strokeId: strokeIdRef.current,
+				x: p.x,
+				y: p.y,
+			});
+		}
+	});
+
+	const schedule = useEffectEvent((p: { x: number; y: number }) => {
+		pendingPointRef.current = p;
+		if (rafHandleRef.current !== null) return;
+		rafHandleRef.current = requestAnimationFrame(flushPendingPoint);
+	});
+
+	const handleLeave = useEffectEvent(() => {
+		pendingPointRef.current = null;
+		if (toolMode === "laser") {
+			setLaserPos(null);
+			sendTool(fileName, pairId, selfSide, { command: "pointer-leave" });
+		}
+	});
+
+	const handleDown = useEffectEvent((event: PointerEvent, el: HTMLElement) => {
+		if (toolMode !== "pen") return;
+		if (event.button !== 0) return;
+		event.preventDefault();
+		const rect = el.getBoundingClientRect();
+		const x = Math.max(
+			0,
+			Math.min(1, (event.clientX - rect.left) / rect.width),
+		);
+		const y = Math.max(
+			0,
+			Math.min(1, (event.clientY - rect.top) / rect.height),
+		);
+		const strokeId =
+			typeof crypto.randomUUID === "function"
+				? crypto.randomUUID()
+				: `stroke-${Date.now()}-${Math.random()}`;
+		strokeIdRef.current = strokeId;
+		doAddPenStroke({ strokeId, x, y });
+		sendTool(fileName, pairId, selfSide, {
+			command: "pen-stroke-start",
+			strokeId,
+			x,
+			y,
+		});
+		(event.target as Element).setPointerCapture?.(event.pointerId);
+	});
+
+	const handleUp = useEffectEvent((event: PointerEvent) => {
+		if (!strokeIdRef.current) return;
+		const strokeId = strokeIdRef.current;
+		strokeIdRef.current = null;
+		doEndPenStroke({ strokeId });
+		sendTool(fileName, pairId, selfSide, {
+			command: "pen-stroke-end",
+			strokeId,
+		});
+		(event.target as Element).releasePointerCapture?.(event.pointerId);
+	});
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		if (toolMode === "none") return;
+
+		const abortController = new AbortController();
+
+		const toNormalized = (event: PointerEvent): { x: number; y: number } => {
+			const rect = el.getBoundingClientRect();
+			const x = (event.clientX - rect.left) / rect.width;
+			const y = (event.clientY - rect.top) / rect.height;
+			return {
+				x: Math.max(0, Math.min(1, x)),
+				y: Math.max(0, Math.min(1, y)),
+			};
+		};
+
+		el.addEventListener(
+			"pointermove",
+			(event: PointerEvent) => schedule(toNormalized(event)),
+			{ signal: abortController.signal },
+		);
+		el.addEventListener("pointerleave", () => handleLeave(), {
+			signal: abortController.signal,
+		});
+		el.addEventListener(
+			"pointerdown",
+			(event: PointerEvent) => handleDown(event, el),
+			{
+				signal: abortController.signal,
+			},
+		);
+		el.addEventListener("pointerup", (event: PointerEvent) => handleUp(event), {
+			signal: abortController.signal,
+		});
+		el.addEventListener(
+			"pointercancel",
+			(event: PointerEvent) => handleUp(event),
+			{
+				signal: abortController.signal,
+			},
+		);
+
+		return () => {
+			abortController.abort();
+			if (rafHandleRef.current !== null) {
+				cancelAnimationFrame(rafHandleRef.current);
+				rafHandleRef.current = null;
+			}
+		};
+	}, [containerRef, toolMode]);
+}

--- a/src/routes/-hooks/use-tool-shortcut.ts
+++ b/src/routes/-hooks/use-tool-shortcut.ts
@@ -1,0 +1,73 @@
+import { useAtom, useSetAtom } from "jotai";
+import { useEffect, useEffectEvent } from "react";
+import { sendTool, type ToolSide } from "#src/broadcast";
+import {
+	clearPenStrokes,
+	type ToolMode,
+	toolModeAtom,
+} from "#src/lib/pointer-state.ts";
+
+export function useToolShortcut(
+	fileName: string,
+	pairId: string,
+	selfSide: ToolSide,
+): void {
+	const [toolMode, setToolMode] = useAtom(toolModeAtom);
+	const doClearStrokes = useSetAtom(clearPenStrokes);
+
+	const changeMode = useEffectEvent((next: ToolMode) => {
+		setToolMode(next);
+		sendTool(fileName, pairId, selfSide, { command: "tool-mode", mode: next });
+	});
+
+	const clearPen = useEffectEvent(() => {
+		doClearStrokes();
+		sendTool(fileName, pairId, selfSide, { command: "pen-clear" });
+	});
+
+	const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
+		if (event.defaultPrevented) return;
+		// IME やテキスト入力中は無視
+		const target = event.target as HTMLElement | null;
+		if (
+			target &&
+			(target.tagName === "INPUT" ||
+				target.tagName === "TEXTAREA" ||
+				target.isContentEditable)
+		) {
+			return;
+		}
+
+		switch (event.key) {
+			case "l":
+			case "L":
+				event.preventDefault();
+				changeMode(toolMode === "laser" ? "none" : "laser");
+				break;
+			case "d":
+			case "D":
+				event.preventDefault();
+				changeMode(toolMode === "pen" ? "none" : "pen");
+				break;
+			case "e":
+			case "E":
+				event.preventDefault();
+				clearPen();
+				break;
+			case "Escape":
+				if (toolMode !== "none") {
+					event.preventDefault();
+					changeMode("none");
+				}
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const abortController = new AbortController();
+		window.addEventListener("keydown", onKeyDown, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, []);
+}

--- a/src/routes/-hooks/use-tool-shortcut.ts
+++ b/src/routes/-hooks/use-tool-shortcut.ts
@@ -38,27 +38,26 @@ export function useToolShortcut(
 			return;
 		}
 
-		switch (event.key) {
+		if (event.key === "Escape") {
+			if (toolMode !== "none") {
+				event.preventDefault();
+				changeMode("none");
+			}
+			return;
+		}
+
+		switch (event.key.toLowerCase()) {
 			case "l":
-			case "L":
 				event.preventDefault();
 				changeMode(toolMode === "laser" ? "none" : "laser");
 				break;
 			case "d":
-			case "D":
 				event.preventDefault();
 				changeMode(toolMode === "pen" ? "none" : "pen");
 				break;
 			case "e":
-			case "E":
 				event.preventDefault();
 				clearPen();
-				break;
-			case "Escape":
-				if (toolMode !== "none") {
-					event.preventDefault();
-					changeMode("none");
-				}
 				break;
 		}
 	});

--- a/src/routes/-hooks/use-tool-shortcut.ts
+++ b/src/routes/-hooks/use-tool-shortcut.ts
@@ -3,6 +3,7 @@ import { useEffect, useEffectEvent } from "react";
 import { sendTool, type ToolSide } from "#src/broadcast";
 import {
 	clearPenStrokes,
+	laserPosAtom,
 	type ToolMode,
 	toolModeAtom,
 } from "#src/lib/pointer-state.ts";
@@ -14,8 +15,11 @@ export function useToolShortcut(
 ): void {
 	const [toolMode, setToolMode] = useAtom(toolModeAtom);
 	const doClearStrokes = useSetAtom(clearPenStrokes);
+	const setLaserPos = useSetAtom(laserPosAtom);
 
 	const changeMode = useEffectEvent((next: ToolMode) => {
+		// 前モードの残像を避けるため、切替時にレーザー位置をリセット
+		setLaserPos(null);
 		setToolMode(next);
 		sendTool(fileName, pairId, selfSide, { command: "tool-mode", mode: next });
 	});

--- a/src/routes/presentation/-Menu.tsx
+++ b/src/routes/presentation/-Menu.tsx
@@ -1,9 +1,11 @@
 import type { ClassValue } from "clsx";
+import { useAtomValue } from "jotai";
 import { MaximizeIcon, MinimizeIcon } from "lucide-react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import { Button } from "#src/components/ui/button.tsx";
 import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
+import { toolModeAtom } from "#src/lib/pointer-state.ts";
 import { cn } from "#src/lib/utils.ts";
 
 interface MenuProps {
@@ -23,6 +25,7 @@ export function Menu({ pdfpcConfig, currentPageNumber, className }: MenuProps) {
 	// ここで表示/非表示を制御します
 	const [visible, setVisible] = useState<boolean>(true);
 	const hideTimerRef = useRef<number | null>(null);
+	const toolMode = useAtomValue(toolModeAtom);
 
 	const scheduleHide = useEffectEvent((): void => {
 		if (hideTimerRef.current) {
@@ -41,13 +44,21 @@ export function Menu({ pdfpcConfig, currentPageNumber, className }: MenuProps) {
 	});
 
 	useEffect(() => {
+		if (toolMode !== "none") {
+			// ツール使用中はメニューを出さない
+			if (hideTimerRef.current) {
+				window.clearTimeout(hideTimerRef.current);
+				hideTimerRef.current = null;
+			}
+			setVisible(false);
+			return;
+		}
+
 		scheduleHide();
 
 		const onPointerMove = (): void => {
 			showAndResetTimer();
 		};
-
-		// クリック/タップでも表示したい場合
 		const onPointerDown = (): void => {
 			showAndResetTimer();
 		};
@@ -63,7 +74,7 @@ export function Menu({ pdfpcConfig, currentPageNumber, className }: MenuProps) {
 				hideTimerRef.current = null;
 			}
 		};
-	}, []);
+	}, [toolMode]);
 	const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
 
 	useEffect(() => {

--- a/src/routes/presentation/-SlideStage.tsx
+++ b/src/routes/presentation/-SlideStage.tsx
@@ -1,5 +1,6 @@
 import type { ClassValue } from "clsx";
 import type { PDFDocumentProxy } from "pdfjs-dist";
+import type { ReactNode, RefObject } from "react";
 import { PdfPage } from "#src/components/PdfPage.tsx";
 import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
 import { cn } from "#src/lib/utils.ts";
@@ -10,6 +11,8 @@ interface SlideStageProps {
 	currentPageNumber: number;
 	isBlackout: boolean;
 	className?: ClassValue;
+	stageRef?: RefObject<HTMLDivElement | null>;
+	children?: ReactNode;
 }
 
 function preloadSlide(
@@ -31,10 +34,12 @@ export function SlideStage({
 	currentPageNumber,
 	isBlackout,
 	className,
+	stageRef,
+	children,
 }: SlideStageProps) {
 	const preloadPages = preloadSlide(pdfpcConfig, currentPageNumber);
 	return (
-		<div className={cn("relative", className)}>
+		<div className={cn("relative", className)} ref={stageRef}>
 			{preloadPages.map((pageNumber) => (
 				<PdfPage
 					key={pageNumber}
@@ -49,6 +54,7 @@ export function SlideStage({
 					]}
 				/>
 			))}
+			{children}
 		</div>
 	);
 }

--- a/src/routes/presentation/-hooks/use-presentation-shortcut.ts
+++ b/src/routes/presentation/-hooks/use-presentation-shortcut.ts
@@ -1,0 +1,38 @@
+import { useEffect, useEffectEvent } from "react";
+import { sendNavigate } from "#src/broadcast";
+
+export function usePresentationShortcut(fileName: string, pairId: string) {
+	const onKeyDown = useEffectEvent((event: KeyboardEvent) => {
+		if (event.defaultPrevented) return;
+
+		switch (event.key) {
+			case " ":
+			case "ArrowRight":
+			case "PageDown":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "next");
+				break;
+			case "ArrowLeft":
+			case "PageUp":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "prev");
+				break;
+			case "Home":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "home");
+				break;
+			case "End":
+				event.preventDefault();
+				sendNavigate(fileName, pairId, "end");
+				break;
+		}
+	});
+
+	useEffect(() => {
+		const abortController = new AbortController();
+		window.addEventListener("keydown", onKeyDown, {
+			signal: abortController.signal,
+		});
+		return () => abortController.abort();
+	}, []);
+}

--- a/src/routes/presentation/index.tsx
+++ b/src/routes/presentation/index.tsx
@@ -8,6 +8,7 @@ import {
 	use,
 	useEffect,
 	useEffectEvent,
+	useRef,
 	useState,
 	useTransition,
 } from "react";
@@ -15,15 +16,19 @@ import * as typia from "typia";
 import {
 	getPresentationPairId,
 	usePresentationBroadcast,
+	useToolBroadcast,
 } from "#src/broadcast";
 import { ErrorBoundary } from "#src/components/ErrorBoundary.tsx";
 import { OverviewDialog } from "#src/components/OverviewDialog";
+import { PointerOverlay } from "#src/components/PointerOverlay.tsx";
 import { Button } from "#src/components/ui/button.tsx";
 import { Skeleton } from "#src/components/ui/skeleton.tsx";
 import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
 import { getRecentFileById, openDb } from "#src/lib/recent-store.ts";
 import { createUseMemoried } from "#src/lib/use-memoried.ts";
 import { cn } from "#src/lib/utils.ts";
+import { usePointerEmitter } from "#src/routes/-hooks/use-pointer-emitter";
+import { useToolShortcut } from "#src/routes/-hooks/use-tool-shortcut";
 import { usePresentationShortcut } from "./-hooks/use-presentation-shortcut";
 import { Menu } from "./-Menu";
 import { SlideStage } from "./-SlideStage";
@@ -274,6 +279,12 @@ function PresentationView({
 
 	usePresentationShortcut(fileName, pairId);
 
+	const stageRef = useRef<HTMLDivElement | null>(null);
+
+	useToolBroadcast(fileName, pairId, "presentation");
+	useToolShortcut(fileName, pairId, "presentation");
+	usePointerEmitter(stageRef, fileName, pairId, "presentation");
+
 	const onKeyDown = useEffectEvent((e: KeyboardEvent) => {
 		if (e.key === "f") {
 			if (document.fullscreenElement) {
@@ -302,7 +313,10 @@ function PresentationView({
 				pdfpcConfig={pdfpcConfig}
 				currentPageNumber={currentPageNumber}
 				isBlackout={currentIsBlackout}
-			/>
+				stageRef={stageRef}
+			>
+				<PointerOverlay />
+			</SlideStage>
 			<div
 				className={cn([
 					"absolute bottom-24 w-full flex justify-center",

--- a/src/routes/presentation/index.tsx
+++ b/src/routes/presentation/index.tsx
@@ -24,6 +24,7 @@ import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
 import { getRecentFileById, openDb } from "#src/lib/recent-store.ts";
 import { createUseMemoried } from "#src/lib/use-memoried.ts";
 import { cn } from "#src/lib/utils.ts";
+import { usePresentationShortcut } from "./-hooks/use-presentation-shortcut";
 import { Menu } from "./-Menu";
 import { SlideStage } from "./-SlideStage";
 
@@ -210,7 +211,14 @@ function PresentationBroadcastData({
 		);
 	}
 
-	return <PresentationView {...initData} localPdf={pdf} />;
+	return (
+		<PresentationView
+			{...initData}
+			localPdf={pdf}
+			fileName={fileName}
+			pairId={pairId}
+		/>
+	);
 }
 
 const getPdfBuffer = createUseMemoried(
@@ -229,12 +237,16 @@ function PresentationView({
 	pageNumber,
 	isBlackout,
 	localPdf,
+	fileName,
+	pairId,
 }: {
 	pdfpcConfig: ResolvedPdfpcConfigV2;
 	pdfData: ArrayBuffer;
 	pageNumber: number;
 	isBlackout: boolean;
 	localPdf?: File | FileSystemFileHandle;
+	fileName: string;
+	pairId: string;
 }) {
 	const pdfBuffer = use(
 		localPdf ? getPdfBuffer(localPdf) : Promise.resolve(pdfData),
@@ -259,6 +271,8 @@ function PresentationView({
 		pdfProxy: !!pdfProxy,
 		pdfpcPages: pdfpcConfig.pages.length,
 	});
+
+	usePresentationShortcut(fileName, pairId);
 
 	const onKeyDown = useEffectEvent((e: KeyboardEvent) => {
 		if (e.key === "f") {

--- a/src/routes/presentation/index.tsx
+++ b/src/routes/presentation/index.tsx
@@ -286,6 +286,7 @@ function PresentationView({
 	usePointerEmitter(stageRef, fileName, pairId, "presentation");
 
 	const onKeyDown = useEffectEvent((e: KeyboardEvent) => {
+		if (e.defaultPrevented) return;
 		if (e.key === "f") {
 			if (document.fullscreenElement) {
 				document.exitFullscreen();


### PR DESCRIPTION
## Summary

- **presentation 画面からのバックアップページ送り**: Space / 矢印 / PageUp/Down / Home/End で `navigate` コマンドを broadcast、presenter 側で解決して両画面同期
- **レーザーポインター** (`L` トグル) と **ペン** (`D` トグル、赤 3px 固定、ページ遷移で自動クリア、`E` で手動クリア) を両画面双方向同期で追加
- **ツール中は presentation メニューの自動表示を抑制** し、カーソルでの指し示しを邪魔しないように
- **プロジェクト初の vitest テスト導入** (navigation-utils 14件 + pointer-state 8件 = 22件)

## 設計書と実装計画

- Spec: [`docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md`](../blob/feat/presentation-controls-and-pointer-tools/docs/superpowers/specs/2026-04-24-presentation-controls-and-pointer-tools-design.md)
- Plan: [`docs/superpowers/plans/2026-04-24-presentation-controls-and-pointer-tools.md`](../blob/feat/presentation-controls-and-pointer-tools/docs/superpowers/plans/2026-04-24-presentation-controls-and-pointer-tools.md)

## キーバインド

| Key | 動作 | 有効画面 |
|---|---|---|
| `L` | レーザー トグル | 両方 |
| `D` | ペン トグル | 両方 |
| `E` | ペン描画全消去 | 両方 |
| `Esc` | ツールモード解除 | 両方 |
| `Space` / `→` / `PageDown` | 次ページ | 両方 |
| `←` / `PageUp` | 前ページ | 両方 |
| `Home` / `End` | 先頭/末尾 | 両方 |

## アーキテクチャ

- 双方向 broadcast: どちらの画面でツール操作してもペア側に同期
- 正規化座標 (0-1) で送信しアスペクト比に依存せず位置が一致
- `requestAnimationFrame` スロットリングで pointer-move を最大 60fps に抑制
- ペン: `setPointerCapture` でドラッグがスライド外に出てもストローク継続
- `PointerOverlay` は SVG `viewBox=\"0 0 1 1\"` + `preserveAspectRatio=\"none\"` で正規化座標を直接使用、各ストロークを `React.memo` 化して変更ストロークのみ再描画

## Test plan

- [ ] presentation 画面にフォーカスし、`Space`/矢印/PageUp/Down/Home/End でページが両画面同期で進む
- [ ] presenter で `L` → 両画面にレーザーが表示され、マウス移動が同期追従する
- [ ] presentation で `L` → 両画面にレーザー（双方向）
- [ ] presenter で `D` にしてドラッグ → 両画面に赤い線が描画される
- [ ] presentation で `D` にしてドラッグ → 同上（双方向）
- [ ] ページ遷移で両画面のペン描画が消える
- [ ] `E` で両画面のペン描画が即座に消える
- [ ] `Esc` でツールモードが解除される
- [ ] presentation 画面でツール中はマウス移動しても自動メニューが出ない
- [ ] `pnpm test` / `pnpm tsc -b` / `pnpm check` / `pnpm build` 全て緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)