### PR TITLE
fix(pointer): ポインター overlay の表示・同期・干渉バグを修正

### DIFF
--- a/src/components/PdfPage.tsx
+++ b/src/components/PdfPage.tsx
@@ -2,6 +2,7 @@ import type { ClassValue } from "clsx";
 import type { PageViewport, PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist";
 import {
 	type HTMLAttributes,
+	type ReactNode,
 	type RefObject,
 	Suspense,
 	use,
@@ -15,11 +16,13 @@ import { cn } from "#src/lib/utils";
 import { Skeleton } from "./ui/skeleton";
 
 interface PdfPageProps
-	extends Omit<HTMLAttributes<HTMLDivElement>, "className"> {
+	extends Omit<HTMLAttributes<HTMLDivElement>, "className" | "children"> {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	className?: ClassValue;
 	ref?: RefObject<HTMLDivElement | null>;
+	pdfAreaRef?: RefObject<HTMLDivElement | null>;
+	children?: ReactNode;
 }
 
 export function PdfPage({
@@ -27,6 +30,8 @@ export function PdfPage({
 	pageNumber,
 	className,
 	ref,
+	pdfAreaRef,
+	children,
 	...props
 }: PdfPageProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
@@ -47,7 +52,10 @@ export function PdfPage({
 					pdfProxy={pdfProxy}
 					pageNumber={pageNumber}
 					containerRef={ref ? ref : containerRef}
-				/>
+					pdfAreaRef={pdfAreaRef}
+				>
+					{children}
+				</PdfPageCanvas>
 			</Suspense>
 		</div>
 	);
@@ -122,10 +130,14 @@ function PdfPageCanvas({
 	pdfProxy,
 	pageNumber,
 	containerRef,
+	pdfAreaRef,
+	children,
 }: {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	containerRef: RefObject<HTMLDivElement | null>;
+	pdfAreaRef?: RefObject<HTMLDivElement | null>;
+	children?: ReactNode;
 }) {
 	const page = use(getPage(pdfProxy, pageNumber));
 	const baseViewport = useMemo(() => page.getViewport({ scale: 1 }), [page]);
@@ -201,8 +213,6 @@ function PdfPageCanvas({
 		});
 		canvas.width = Math.floor(scaledViewport.width);
 		canvas.height = Math.floor(scaledViewport.height);
-		canvas.style.width = `${Math.floor(viewport.width)}px`;
-		canvas.style.height = `${Math.floor(viewport.height)}px`;
 
 		const renderTask = page.render({
 			canvas,
@@ -216,7 +226,23 @@ function PdfPageCanvas({
 		};
 	}, [page, viewport]);
 
-	return <canvas ref={canvasRef} className="block max-h-full max-w-full" />;
+	const wrapperStyle = viewport
+		? {
+				width: `${Math.floor(viewport.width)}px`,
+				height: `${Math.floor(viewport.height)}px`,
+			}
+		: undefined;
+
+	return (
+		<div
+			ref={pdfAreaRef}
+			className="relative max-h-full max-w-full"
+			style={wrapperStyle}
+		>
+			<canvas ref={canvasRef} className="block h-full w-full" />
+			{children}
+		</div>
+	);
 }
 function getContentBoxSize(el: HTMLElement): DOMRectReadOnly {
 	const style = window.getComputedStyle(el);

--- a/src/components/PdfPage.tsx
+++ b/src/components/PdfPage.tsx
@@ -2,7 +2,6 @@ import type { ClassValue } from "clsx";
 import type { PageViewport, PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist";
 import {
 	type HTMLAttributes,
-	type ReactNode,
 	type RefObject,
 	Suspense,
 	use,
@@ -16,13 +15,12 @@ import { cn } from "#src/lib/utils";
 import { Skeleton } from "./ui/skeleton";
 
 interface PdfPageProps
-	extends Omit<HTMLAttributes<HTMLDivElement>, "className" | "children"> {
+	extends Omit<HTMLAttributes<HTMLDivElement>, "className"> {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	className?: ClassValue;
 	ref?: RefObject<HTMLDivElement | null>;
 	pdfAreaRef?: RefObject<HTMLDivElement | null>;
-	children?: ReactNode;
 }
 
 export function PdfPage({
@@ -31,7 +29,6 @@ export function PdfPage({
 	className,
 	ref,
 	pdfAreaRef,
-	children,
 	...props
 }: PdfPageProps) {
 	const containerRef = useRef<HTMLDivElement | null>(null);
@@ -53,9 +50,7 @@ export function PdfPage({
 					pageNumber={pageNumber}
 					containerRef={ref ? ref : containerRef}
 					pdfAreaRef={pdfAreaRef}
-				>
-					{children}
-				</PdfPageCanvas>
+				/>
 			</Suspense>
 		</div>
 	);
@@ -131,13 +126,11 @@ function PdfPageCanvas({
 	pageNumber,
 	containerRef,
 	pdfAreaRef,
-	children,
 }: {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	containerRef: RefObject<HTMLDivElement | null>;
 	pdfAreaRef?: RefObject<HTMLDivElement | null>;
-	children?: ReactNode;
 }) {
 	const page = use(getPage(pdfProxy, pageNumber));
 	const baseViewport = useMemo(() => page.getViewport({ scale: 1 }), [page]);
@@ -240,7 +233,6 @@ function PdfPageCanvas({
 			style={wrapperStyle}
 		>
 			<canvas ref={canvasRef} className="block h-full w-full" />
-			{children}
 		</div>
 	);
 }

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -55,7 +55,10 @@ export function PointerOverlay({
 		}
 	}, [toolMode, containerRef]);
 
-	// laser 位置は React 再レンダーをバイパスして直接 DOM を更新する (追従性向上)
+	// laser 位置は React 再レンダーをバイパスして直接 DOM を更新する (追従性向上)。
+	// 操作側 (usePointerEmitter の setLaserPos) と同期受信側 (useToolBroadcast の
+	// setLaserPos) 双方が同じ atom を更新するため、この store.sub 経由の DOM 更新に
+	// 一本化することで、ローカル操作とブロードキャスト受信の両方が同経路で流れる。
 	useEffect(() => {
 		const applyPos = () => {
 			const el = laserRef.current;

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -102,9 +102,8 @@ export function PointerOverlay({
 					className="absolute inset-0 h-full w-full pointer-events-none"
 					viewBox="0 0 1 1"
 					preserveAspectRatio="none"
-					aria-hidden="true"
+					role="presentation"
 				>
-					<title>pen strokes</title>
 					{strokes.map((stroke) => (
 						<Stroke key={stroke.id} stroke={stroke} />
 					))}
@@ -136,11 +135,7 @@ function useContainerRect(ref: RefObject<HTMLElement | null>) {
 	return rect;
 }
 
-const LaserDot = function LaserDot({
-	ref,
-}: {
-	ref: RefObject<HTMLDivElement | null>;
-}) {
+function LaserDot({ ref }: { ref: RefObject<HTMLDivElement | null> }) {
 	// 1 つのラッパー (0x0 の点) を ref で直接更新することで、halo/core の位置を一括で動かす
 	return (
 		<div
@@ -179,4 +174,4 @@ const LaserDot = function LaserDot({
 			/>
 		</div>
 	);
-};
+}

--- a/src/components/PointerOverlay.tsx
+++ b/src/components/PointerOverlay.tsx
@@ -1,5 +1,6 @@
-import { useAtomValue } from "jotai";
-import { memo } from "react";
+import { useAtomValue, useStore } from "jotai";
+import { memo, type RefObject, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
 	laserPosAtom,
 	type PenStroke,
@@ -10,6 +11,7 @@ import { cn } from "#src/lib/utils.ts";
 
 interface PointerOverlayProps {
 	className?: string;
+	containerRef: RefObject<HTMLElement | null>;
 }
 
 const PEN_COLOR = "#ef4444";
@@ -31,33 +33,147 @@ const Stroke = memo(function Stroke({ stroke }: { stroke: PenStroke }) {
 	);
 });
 
-export function PointerOverlay({ className }: PointerOverlayProps) {
+export function PointerOverlay({
+	className,
+	containerRef,
+}: PointerOverlayProps) {
 	const toolMode = useAtomValue(toolModeAtom);
-	const laserPos = useAtomValue(laserPosAtom);
 	const strokes = useAtomValue(penStrokesAtom);
+	const rect = useContainerRect(containerRef);
+	const store = useStore();
+	const laserRef = useRef<HTMLDivElement | null>(null);
+
+	// laser モード中はレーザードットが指示点を示すのでネイティブカーソルを消す
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		if (toolMode === "laser") {
+			el.style.cursor = "none";
+			return () => {
+				el.style.cursor = "";
+			};
+		}
+	}, [toolMode, containerRef]);
+
+	// laser 位置は React 再レンダーをバイパスして直接 DOM を更新する (追従性向上)
+	useEffect(() => {
+		const applyPos = () => {
+			const el = laserRef.current;
+			if (!el) return;
+			const pos = store.get(laserPosAtom);
+			if (pos === null || store.get(toolModeAtom) !== "laser") {
+				el.style.display = "none";
+			} else {
+				el.style.display = "";
+				el.style.left = `${pos.x * 100}%`;
+				el.style.top = `${pos.y * 100}%`;
+			}
+		};
+		applyPos();
+		const unsubPos = store.sub(laserPosAtom, applyPos);
+		const unsubMode = store.sub(toolModeAtom, applyPos);
+		return () => {
+			unsubPos();
+			unsubMode();
+		};
+	}, [store]);
 
 	if (toolMode === "none" && strokes.length === 0) return null;
+	if (!rect) return null;
 
-	return (
-		<svg
-			className={cn("absolute inset-0 pointer-events-none", className)}
-			viewBox="0 0 1 1"
-			preserveAspectRatio="none"
+	// viewport 内の固定レイヤーとして document.body に portal することで、
+	// Menu 等の兄弟要素とのスタッキング順に巻き込まれないようにする
+	return createPortal(
+		<div
 			aria-hidden="true"
+			className={cn("fixed pointer-events-none z-50", className)}
+			style={{
+				left: rect.left,
+				top: rect.top,
+				width: rect.width,
+				height: rect.height,
+			}}
 		>
-			{strokes.map((stroke) => (
-				<Stroke key={stroke.id} stroke={stroke} />
-			))}
-			{toolMode === "laser" && laserPos !== null ? (
-				<circle
-					cx={laserPos.x}
-					cy={laserPos.y}
-					r={0.008}
-					fill={PEN_COLOR}
-					opacity={0.8}
-					style={{ mixBlendMode: "multiply" }}
-				/>
+			{strokes.length > 0 ? (
+				<svg
+					className="absolute inset-0 h-full w-full pointer-events-none"
+					viewBox="0 0 1 1"
+					preserveAspectRatio="none"
+					aria-hidden="true"
+				>
+					<title>pen strokes</title>
+					{strokes.map((stroke) => (
+						<Stroke key={stroke.id} stroke={stroke} />
+					))}
+				</svg>
 			) : null}
-		</svg>
+			<LaserDot ref={laserRef} />
+		</div>,
+		document.body,
 	);
 }
+
+function useContainerRect(ref: RefObject<HTMLElement | null>) {
+	const [rect, setRect] = useState<DOMRect | null>(null);
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		const update = () => setRect(el.getBoundingClientRect());
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(el);
+		window.addEventListener("resize", update);
+		window.addEventListener("scroll", update, true);
+		return () => {
+			observer.disconnect();
+			window.removeEventListener("resize", update);
+			window.removeEventListener("scroll", update, true);
+		};
+	}, [ref]);
+	return rect;
+}
+
+const LaserDot = function LaserDot({
+	ref,
+}: {
+	ref: RefObject<HTMLDivElement | null>;
+}) {
+	// 1 つのラッパー (0x0 の点) を ref で直接更新することで、halo/core の位置を一括で動かす
+	return (
+		<div
+			ref={ref}
+			className="absolute"
+			style={{ display: "none", width: 0, height: 0 }}
+		>
+			<div
+				className="absolute"
+				style={{
+					left: 0,
+					top: 0,
+					width: 32,
+					height: 32,
+					transform: "translate(-50%, -50%)",
+					borderRadius: "9999px",
+					background:
+						"radial-gradient(circle, rgba(255,120,120,0.6) 0%, rgba(239,68,68,0.45) 35%, rgba(239,68,68,0) 75%)",
+					filter: "blur(1px)",
+				}}
+			/>
+			<div
+				className="absolute"
+				style={{
+					left: 0,
+					top: 0,
+					width: 12,
+					height: 12,
+					transform: "translate(-50%, -50%)",
+					borderRadius: "9999px",
+					background:
+						"radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(255,240,240,1) 25%, rgba(239,68,68,1) 70%, rgba(200,30,30,1) 100%)",
+					boxShadow:
+						"0 0 4px 1px rgba(239,68,68,0.9), 0 0 10px 3px rgba(239,68,68,0.55)",
+				}}
+			/>
+		</div>
+	);
+};

--- a/src/routes/(main)/-presenter/SlideStage.tsx
+++ b/src/routes/(main)/-presenter/SlideStage.tsx
@@ -9,12 +9,14 @@ export const SlideStage = function SlideStage({
 	pageNumber,
 	className,
 	ref,
+	pdfAreaRef,
 	children,
 }: {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	className?: ClassValue;
 	ref?: RefObject<HTMLElement | null>;
+	pdfAreaRef?: RefObject<HTMLDivElement | null>;
 	children?: ReactNode;
 }) {
 	return (
@@ -23,8 +25,10 @@ export const SlideStage = function SlideStage({
 				pdfProxy={pdfProxy}
 				pageNumber={pageNumber}
 				className="absolute inset-0"
-			/>
-			{children}
+				pdfAreaRef={pdfAreaRef}
+			>
+				{children}
+			</PdfPage>
 		</section>
 	);
 };

--- a/src/routes/(main)/-presenter/SlideStage.tsx
+++ b/src/routes/(main)/-presenter/SlideStage.tsx
@@ -1,6 +1,6 @@
 import type { ClassValue } from "clsx";
 import type { PDFDocumentProxy } from "pdfjs-dist";
-import type { ReactNode, RefObject } from "react";
+import type { RefObject } from "react";
 import { PdfPage } from "#src/components/PdfPage.tsx";
 import { cn } from "#src/lib/utils.ts";
 
@@ -10,14 +10,12 @@ export const SlideStage = function SlideStage({
 	className,
 	ref,
 	pdfAreaRef,
-	children,
 }: {
 	pdfProxy: PDFDocumentProxy;
 	pageNumber: number;
 	className?: ClassValue;
 	ref?: RefObject<HTMLElement | null>;
 	pdfAreaRef?: RefObject<HTMLDivElement | null>;
-	children?: ReactNode;
 }) {
 	return (
 		<section className={cn("relative", className)} ref={ref}>
@@ -26,9 +24,7 @@ export const SlideStage = function SlideStage({
 				pageNumber={pageNumber}
 				className="absolute inset-0"
 				pdfAreaRef={pdfAreaRef}
-			>
-				{children}
-			</PdfPage>
+			/>
 		</section>
 	);
 };

--- a/src/routes/(main)/presenter.tsx
+++ b/src/routes/(main)/presenter.tsx
@@ -125,6 +125,7 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 	const [isOverviewMode, setIsOverviewMode] = useState(false);
 
 	const slideStageRef = useRef<HTMLElement | null>(null);
+	const pdfAreaRef = useRef<HTMLDivElement | null>(null);
 	const nextSlideRef = useRef<HTMLDivElement | null>(null);
 	const nextPrevRef = useRef<HTMLDivElement | null>(null);
 	const timerRef = useRef<TimerHandle | null>(null);
@@ -304,7 +305,7 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 
 	useToolBroadcast(fileName, pairId, "presenter");
 	useToolShortcut(fileName, pairId, "presenter");
-	usePointerEmitter(slideStageRef, fileName, pairId, "presenter");
+	usePointerEmitter(pdfAreaRef, fileName, pairId, "presenter");
 
 	// ページ遷移時にペンストロークを自動クリア（初回マウント時の無駄な broadcast は避ける）
 	const doClearStrokes = useSetAtom(clearPenStrokes);
@@ -324,9 +325,9 @@ function PresenterContent({ pdf, fileName }: { pdf: File; fileName: string }) {
 					pageNumber={pageNumber}
 					className="aspect-video h-full max-w-full place-self-center"
 					ref={slideStageRef}
-				>
-					<PointerOverlay />
-				</SlideStage>
+					pdfAreaRef={pdfAreaRef}
+				/>
+				<PointerOverlay containerRef={pdfAreaRef} />
 				<div className="row-span-2 flex flex-col gap-4">
 					<NextSlide
 						currentSlidePage={pageNumber}

--- a/src/routes/-hooks/use-pointer-emitter.ts
+++ b/src/routes/-hooks/use-pointer-emitter.ts
@@ -107,6 +107,7 @@ export function usePointerEmitter(
 
 	const handleLeave = useEffectEvent(() => {
 		pendingLaserRef.current = null;
+		pendingPenPointsRef.current = [];
 		if (toolMode === "laser") {
 			setLaserPos(null);
 			sendTool(fileName, pairId, selfSide, { command: "pointer-leave" });

--- a/src/routes/-hooks/use-pointer-emitter.ts
+++ b/src/routes/-hooks/use-pointer-emitter.ts
@@ -9,15 +9,20 @@ import {
 	toolModeAtom,
 } from "#src/lib/pointer-state.ts";
 
+interface Point {
+	x: number;
+	y: number;
+}
+
 function normalizedPointer(
-	event: PointerEvent,
-	el: HTMLElement,
-): { x: number; y: number } | null {
-	const rect = el.getBoundingClientRect();
+	clientX: number,
+	clientY: number,
+	rect: DOMRect,
+): Point | null {
 	if (rect.width === 0 || rect.height === 0) return null;
 	return {
-		x: Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width)),
-		y: Math.max(0, Math.min(1, (event.clientY - rect.top) / rect.height)),
+		x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+		y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
 	};
 }
 
@@ -40,16 +45,17 @@ export function usePointerEmitter(
 	const doEndPenStroke = useSetAtom(endPenStroke);
 
 	const strokeIdRef = useRef<string | null>(null);
-	const pendingPointRef = useRef<{ x: number; y: number } | null>(null);
+	const pendingLaserRef = useRef<Point | null>(null);
+	const pendingPenPointsRef = useRef<Point[]>([]);
 	const rafHandleRef = useRef<number | null>(null);
 
-	const flushPendingPoint = useEffectEvent(() => {
+	const flushPending = useEffectEvent(() => {
 		rafHandleRef.current = null;
-		const p = pendingPointRef.current;
-		if (!p) return;
-		pendingPointRef.current = null;
 
 		if (toolMode === "laser") {
+			const p = pendingLaserRef.current;
+			if (!p) return;
+			pendingLaserRef.current = null;
 			setLaserPos(p);
 			sendTool(fileName, pairId, selfSide, {
 				command: "pointer-move",
@@ -57,30 +63,50 @@ export function usePointerEmitter(
 				y: p.y,
 			});
 		} else if (toolMode === "pen" && strokeIdRef.current) {
-			doAddPenPoint({ strokeId: strokeIdRef.current, x: p.x, y: p.y });
-			sendTool(fileName, pairId, selfSide, {
-				command: "pen-stroke-point",
-				strokeId: strokeIdRef.current,
-				x: p.x,
-				y: p.y,
-			});
+			const pts = pendingPenPointsRef.current;
+			if (pts.length === 0) return;
+			pendingPenPointsRef.current = [];
+			const strokeId = strokeIdRef.current;
+			for (const p of pts) {
+				doAddPenPoint({ strokeId, x: p.x, y: p.y });
+				sendTool(fileName, pairId, selfSide, {
+					command: "pen-stroke-point",
+					strokeId,
+					x: p.x,
+					y: p.y,
+				});
+			}
 		}
 	});
 
 	const handleMove = useEffectEvent((event: PointerEvent) => {
-		// ペンモード中、未 down の間は rAF スケジュールしない
+		// ペンモード中、未 down の間は何もしない
 		if (toolMode === "pen" && !strokeIdRef.current) return;
 		const el = containerRef.current;
 		if (!el) return;
-		const point = normalizedPointer(event, el);
-		if (!point) return;
-		pendingPointRef.current = point;
+		const rect = el.getBoundingClientRect();
+
+		// サブフレームのイベントまで拾ってペンストロークを滑らかに/レーザーは最新位置を採用
+		const coalesced = event.getCoalescedEvents?.() ?? [];
+		const samples = coalesced.length > 0 ? coalesced : [event];
+
+		if (toolMode === "laser") {
+			const latest = samples[samples.length - 1];
+			const p = normalizedPointer(latest.clientX, latest.clientY, rect);
+			if (p) pendingLaserRef.current = p;
+		} else if (toolMode === "pen") {
+			for (const e of samples) {
+				const p = normalizedPointer(e.clientX, e.clientY, rect);
+				if (p) pendingPenPointsRef.current.push(p);
+			}
+		}
+
 		if (rafHandleRef.current !== null) return;
-		rafHandleRef.current = requestAnimationFrame(flushPendingPoint);
+		rafHandleRef.current = requestAnimationFrame(flushPending);
 	});
 
 	const handleLeave = useEffectEvent(() => {
-		pendingPointRef.current = null;
+		pendingLaserRef.current = null;
 		if (toolMode === "laser") {
 			setLaserPos(null);
 			sendTool(fileName, pairId, selfSide, { command: "pointer-leave" });
@@ -92,7 +118,8 @@ export function usePointerEmitter(
 		if (event.button !== 0) return;
 		const el = containerRef.current;
 		if (!el) return;
-		const point = normalizedPointer(event, el);
+		const rect = el.getBoundingClientRect();
+		const point = normalizedPointer(event.clientX, event.clientY, rect);
 		if (!point) return;
 		event.preventDefault();
 		const strokeId = crypto.randomUUID();

--- a/src/routes/presentation/-SlideStage.tsx
+++ b/src/routes/presentation/-SlideStage.tsx
@@ -12,6 +12,7 @@ interface SlideStageProps {
 	isBlackout: boolean;
 	className?: ClassValue;
 	stageRef?: RefObject<HTMLDivElement | null>;
+	pdfAreaRef?: RefObject<HTMLDivElement | null>;
 	children?: ReactNode;
 }
 
@@ -35,26 +36,31 @@ export function SlideStage({
 	isBlackout,
 	className,
 	stageRef,
+	pdfAreaRef,
 	children,
 }: SlideStageProps) {
 	const preloadPages = preloadSlide(pdfpcConfig, currentPageNumber);
 	return (
 		<div className={cn("relative", className)} ref={stageRef}>
-			{preloadPages.map((pageNumber) => (
-				<PdfPage
-					key={pageNumber}
-					pdfProxy={pdfProxy}
-					pageNumber={pageNumber}
-					className={[
-						"absolute inset-0",
-						{
-							"opacity-0 pointer-events-none":
-								pageNumber !== currentPageNumber || isBlackout,
-						},
-					]}
-				/>
-			))}
-			{children}
+			{preloadPages.map((pageNumber) => {
+				const isCurrent = pageNumber === currentPageNumber;
+				return (
+					<PdfPage
+						key={pageNumber}
+						pdfProxy={pdfProxy}
+						pageNumber={pageNumber}
+						className={[
+							"absolute inset-0",
+							{
+								"opacity-0 pointer-events-none": !isCurrent || isBlackout,
+							},
+						]}
+						pdfAreaRef={isCurrent ? pdfAreaRef : undefined}
+					>
+						{isCurrent ? children : null}
+					</PdfPage>
+				);
+			})}
 		</div>
 	);
 }

--- a/src/routes/presentation/-SlideStage.tsx
+++ b/src/routes/presentation/-SlideStage.tsx
@@ -1,6 +1,6 @@
 import type { ClassValue } from "clsx";
 import type { PDFDocumentProxy } from "pdfjs-dist";
-import type { ReactNode, RefObject } from "react";
+import type { RefObject } from "react";
 import { PdfPage } from "#src/components/PdfPage.tsx";
 import type { ResolvedPdfpcConfigV2 } from "#src/lib/pdfpc-config.ts";
 import { cn } from "#src/lib/utils.ts";
@@ -13,7 +13,6 @@ interface SlideStageProps {
 	className?: ClassValue;
 	stageRef?: RefObject<HTMLDivElement | null>;
 	pdfAreaRef?: RefObject<HTMLDivElement | null>;
-	children?: ReactNode;
 }
 
 function preloadSlide(
@@ -37,7 +36,6 @@ export function SlideStage({
 	className,
 	stageRef,
 	pdfAreaRef,
-	children,
 }: SlideStageProps) {
 	const preloadPages = preloadSlide(pdfpcConfig, currentPageNumber);
 	return (
@@ -56,9 +54,7 @@ export function SlideStage({
 							},
 						]}
 						pdfAreaRef={isCurrent ? pdfAreaRef : undefined}
-					>
-						{isCurrent ? children : null}
-					</PdfPage>
+					/>
 				);
 			})}
 		</div>

--- a/src/routes/presentation/index.tsx
+++ b/src/routes/presentation/index.tsx
@@ -280,10 +280,11 @@ function PresentationView({
 	usePresentationShortcut(fileName, pairId);
 
 	const stageRef = useRef<HTMLDivElement | null>(null);
+	const pdfAreaRef = useRef<HTMLDivElement | null>(null);
 
 	useToolBroadcast(fileName, pairId, "presentation");
 	useToolShortcut(fileName, pairId, "presentation");
-	usePointerEmitter(stageRef, fileName, pairId, "presentation");
+	usePointerEmitter(pdfAreaRef, fileName, pairId, "presentation");
 
 	const onKeyDown = useEffectEvent((e: KeyboardEvent) => {
 		if (e.defaultPrevented) return;
@@ -315,14 +316,14 @@ function PresentationView({
 				currentPageNumber={currentPageNumber}
 				isBlackout={currentIsBlackout}
 				stageRef={stageRef}
-			>
-				<PointerOverlay />
-			</SlideStage>
+				pdfAreaRef={pdfAreaRef}
+			/>
+			<PointerOverlay containerRef={pdfAreaRef} />
 			<div
 				className={cn([
-					"absolute bottom-24 w-full flex justify-center",
+					"absolute bottom-24 w-full flex justify-center pointer-events-none",
 					{
-						"opacity-0 pointer-events-none": currentIsBlackout,
+						"opacity-0": currentIsBlackout,
 					},
 				])}
 			>


### PR DESCRIPTION
## Summary

プレゼンテーションツールとして追加されたポインター/ペン機能の複数の不具合を修正し、視覚的な見た目と追従性を改善しました。

### 修正したバグ
- **ポインター ON でスクロール発生** — `viewBox="0 0 1 1"` の SVG は intrinsic aspect ratio 1:1 を持つため、`absolute inset-0` 指定にもかかわらず Chrome が幅に合わせた正方形として展開してセクション(519px)を超え、body 高さが膨らんでいた
- **プレゼンター/プレゼンテーション間の座標ずれ** — stage コンテナのサイズ/比率が両 window で異なり (presenter 873×519, presentation 1200×622, PDF canvas はそれぞれ 873×491, 1105×622)、stage 基準の正規化座標がクロスウィンドウで同じ PDF 位置を指していなかった
- **Menu と重なるとレーザーが消える** — presentation の Menu 本体が `filter: drop-shadow` でスタッキングコンテキストを作り、z-index だけでは越えられなかった。さらに Menu ラッパーが `pointer-events: auto` で hit-testing を吸い、`pdfAreaRef` の pointerleave 発火で laserPos が null に

### 主な実装変更
- `PdfPage` 内に canvas 実寸のラッパー `pdfAreaRef` を追加し、ポインター捕捉・描画の両方をこの要素基準に統一
- `PointerOverlay` を `createPortal` で `document.body` 配下にレンダーし、祖先のスタッキング/overflow から独立
- Menu ラッパーを `pointer-events-none` に変更 (Menu 本体は visible 時のみ `pointer-events-auto`)

### 仕上げ
- レーザーを光沢のあるドット (radial-gradient + box-shadow) に変更し、明/暗どちらの背景でも視認可能に
- laser モード時はネイティブカーソルを非表示
- 追従性向上
  - レーザー位置の更新は `store.sub` + `ref.style` 直接操作で React の reconciliation を回避
  - `pointermove` 内で `getCoalescedEvents()` を使いサブフレームの全サンプルを取得してペンストロークを滑らかに

## Test plan
- [x] `pnpm tsc -b` / `pnpm check` / `pnpm test` (22/22) 通過
- [x] プレゼンター側で laser ON にしてもページがスクロールしない
- [x] プレゼンター側のレーザー位置が、プレゼンテーション側で PDF の同じ相対位置に描画されることを確認
- [x] ペンストロークも同様にクロスウィンドウで一致
- [x] レーザーが Menu バーの上に描画される
- [x] プレゼンテーション側で Menu 領域を通過してもレーザーが消えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)