### PR TITLE
design: コピーリデザイン

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PDFPW is a browser-based PDF presenter console inspired by pdfpc. It features a dual-window architecture:
+pdfpw is a browser-based PDF presenter console inspired by pdfpc. It features a dual-window architecture:
 - **Presenter Window**: Full control interface with notes, next slides, and presenter tools
 - **Presentation Window**: Minimal fullscreen display for the audience
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PDFPW
+# pdfpw
 
-PDFPW is a browser-based PDF presenter console inspired by pdfpc.
+pdfpw is a browser-based PDF presenter console inspired by pdfpc.
 It opens a presenter view and a separate audience window, supports PDF + pdfpc pairing,
 recent file history (when the File System Access API is available), and works entirely in the browser.
 

--- a/docs/superpowers/specs/2026-04-25-copy-redesign.md
+++ b/docs/superpowers/specs/2026-04-25-copy-redesign.md
@@ -1,0 +1,91 @@
+# Copy Redesign
+
+## Scope
+
+- Product name casing (site-wide)
+- Meta title
+- Hero section
+- How It Works section
+
+## Product Name
+
+Change from `PDFPW` to `pdfpw` (all lowercase) everywhere: header logo, page titles, meta tags, OGP, and any other occurrences.
+
+Rationale: echoes the pdfpc naming convention; more authentic to the developer/presenter tool space.
+
+## Meta Title
+
+Titles are defined in two places:
+
+### `src/vite-plugins/locale-html-plugin.ts` (locale-specific static HTML)
+
+| Locale | Before | After |
+|--------|--------|-------|
+| JA | `PDFPW — 精密設計のプレゼンタコンソール` | `pdfpw — ブラウザで動く pdfpc` |
+| EN | `PDFPW — Precise PDF presenter` | `pdfpw — pdfpc in your browser` |
+
+### `index.html` (root fallback + OGP)
+
+| Field | Before | After |
+|-------|--------|-------|
+| `<title>` | `PDFPW – PDF Presenter Web` | `pdfpw — pdfpc in your browser` |
+| `og:title` | `PDFPW – PDF Presenter Web` | `pdfpw — pdfpc in your browser` |
+
+### `messages/ja.json` and `messages/en.json`
+
+The `meta_title` key exists in the message files but is not used at runtime. Update for consistency:
+
+| Locale | Before | After |
+|--------|--------|-------|
+| JA | `PDFPW — 精密設計のプレゼンタコンソール` | `pdfpw — ブラウザで動く pdfpc` |
+| EN | `PDFPW — Precise PDF presenter` | `pdfpw — pdfpc in your browser` |
+
+## Hero Section
+
+### Eyebrow (`hero_eyebrow`)
+
+Remove. The `hero_eyebrow` message key is deleted and the element is removed from `HeroSection.tsx`.
+
+### Headline (`hero_headline_line1`, `hero_headline_line2`)
+
+Shared across both locales (English copy only):
+
+| Key | Value |
+|-----|-------|
+| `hero_headline_line1` | `pdfpc,` |
+| `hero_headline_line2` | `in your browser.` |
+
+### Lead (`hero_lead`)
+
+| Locale | Value |
+|--------|-------|
+| JA | `ブラウザで動くプレゼンタコンソール。インストール・クラウドアップロード不要。` |
+| EN | `A browser-based presenter console. No install, no upload.` |
+
+## How It Works Section
+
+### Step 1
+
+| Key | JA | EN |
+|-----|----|----|
+| `howitworks_step1_title` | `PDF を開く` | `Open a PDF` |
+| `howitworks_step1_body` | `インストール不要。ファイルはブラウザ外に送信されません。.pdfpc 設定ファイルにも対応。` | `No install, no upload. Files stay on your device. pdfpc config files supported.` |
+
+### Step 2
+
+| Key | JA | EN |
+|-----|----|----|
+| `howitworks_step2_title` | `プレゼンテーション画面を開く` | `Open the presentation window` |
+| `howitworks_step2_body` | `プレゼンター画面（ノート・タイマー付き）と客席用フルスクリーンの 2 ウィンドウが同期します。` | `A presenter console with notes and timer, synced to a fullscreen audience display.` |
+
+### Step 3
+
+| Key | JA | EN |
+|-----|----|----|
+| `howitworks_step3_title` | `発表する` | `Present` |
+| `howitworks_step3_body` | `ノート・タイマー・レーザーポインタ・ペン・ブラックアウトをキーボードで操作できます。` | `Notes, timer, laser pointer, pen, and blackout — all keyboard-driven.` |
+
+## Out of Scope
+
+- All other message keys remain unchanged
+- OGP description (`meta_description`) is not changed in this iteration

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
     <link rel="icon" href="/favicon.ico" sizes="16x16 32x32" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="theme-color" content="#0B0B0F" />
-    <title>PDFPW – PDF Presenter Web</title>
+    <title>pdfpw — pdfpc in your browser</title>
     <meta name="description" content="Browser-based PDF presenter console (pdfpc-compatible)." />
     <link rel="canonical" href="https://pdfpw.github.io/en/" />
-    <meta property="og:title" content="PDFPW – PDF Presenter Web" />
+    <meta property="og:title" content="pdfpw — pdfpc in your browser" />
     <meta property="og:description" content="Browser-based PDF presenter console (pdfpc-compatible)." />
     <meta property="og:image" content="https://pdfpw.github.io/og-image.png" />
     <meta property="og:url" content="https://pdfpw.github.io/en/" />

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "smoke_test": "ok",
 
-  "meta_title": "PDFPW — Precise PDF presenter",
+  "meta_title": "pdfpw — pdfpc in your browser",
   "meta_description": "Browser-based PDF presenter console (pdfpc-compatible). No install, no upload.",
 
   "header_help_aria": "Keyboard shortcuts",
@@ -10,10 +10,9 @@
   "header_licenses_aria": "Licenses",
   "header_lang_aria": "Switch language",
 
-  "hero_eyebrow": "PRESENTER CONSOLE / 001",
-  "hero_headline_line1": "Precise by",
-  "hero_headline_line2": "default.",
-  "hero_lead": "A browser-based presenter console. No install, no cloud upload. Your PDF stays on your device.",
+  "hero_headline_line1": "pdfpc,",
+  "hero_headline_line2": "in your browser.",
+  "hero_lead": "A browser-based presenter console. No install, no upload.",
   "hero_open_pdf": "Open PDF",
   "hero_open_with_fsa": "Open with File System Access",
   "hero_drop_label": "Drop a PDF here",
@@ -21,12 +20,12 @@
 
   "howitworks_eyebrow": "HOW IT WORKS",
   "howitworks_steps_count": "3 steps",
-  "howitworks_step1_title": "Open a PDF in your browser",
-  "howitworks_step1_body": "No install, no cloud upload. Your file stays on your device. pdfpc configuration files are supported.",
-  "howitworks_step2_title": "Pop out the presentation",
-  "howitworks_step2_body": "Two synchronized windows: a private presenter console with notes and timer, plus a public fullscreen display.",
-  "howitworks_step3_title": "Present with confidence",
-  "howitworks_step3_body": "Notes, timer, laser pointer, pen, blackout — all keyboard-driven. Stay in flow.",
+  "howitworks_step1_title": "Open a PDF",
+  "howitworks_step1_body": "No install, no upload. Files stay on your device. pdfpc config files supported.",
+  "howitworks_step2_title": "Open the presentation window",
+  "howitworks_step2_body": "A presenter console with notes and timer, synced to a fullscreen audience display.",
+  "howitworks_step3_title": "Present",
+  "howitworks_step3_body": "Notes, timer, laser pointer, pen, and blackout — all keyboard-driven.",
 
   "library_eyebrow": "LIBRARY",
   "library_subtitle_with_count": "{count} files · recent first",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2,7 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "smoke_test": "OK",
 
-  "meta_title": "PDFPW — 精密設計のプレゼンタコンソール",
+  "meta_title": "pdfpw — ブラウザで動く pdfpc",
   "meta_description": "ブラウザベースの PDF プレゼンテーション・コンソール (pdfpc 互換)。インストール不要、アップロード不要。",
 
   "header_help_aria": "キーボードショートカット",
@@ -10,10 +10,9 @@
   "header_licenses_aria": "ライセンス",
   "header_lang_aria": "言語を切り替え",
 
-  "hero_eyebrow": "PRESENTER CONSOLE / 001",
-  "hero_headline_line1": "Precise by",
-  "hero_headline_line2": "default.",
-  "hero_lead": "ブラウザで動くプレゼンタコンソール。インストール・クラウドアップロード不要。PDF はあなたの端末から離れません。",
+  "hero_headline_line1": "pdfpc,",
+  "hero_headline_line2": "in your browser.",
+  "hero_lead": "ブラウザで動くプレゼンタコンソール。インストール・クラウドアップロード不要。",
   "hero_open_pdf": "PDF を開く",
   "hero_open_with_fsa": "File System Access で開く",
   "hero_drop_label": "PDF をここにドロップ",
@@ -21,12 +20,12 @@
 
   "howitworks_eyebrow": "HOW IT WORKS",
   "howitworks_steps_count": "3 ステップ",
-  "howitworks_step1_title": "ブラウザで PDF を開く",
-  "howitworks_step1_body": "インストール・クラウドアップロード不要。ファイルはあなたの端末上にとどまります。pdfpc 設定ファイルにも対応。",
+  "howitworks_step1_title": "PDF を開く",
+  "howitworks_step1_body": "インストール不要。ファイルはブラウザ外に送信されません。.pdfpc 設定ファイルにも対応。",
   "howitworks_step2_title": "プレゼンテーション画面を開く",
-  "howitworks_step2_body": "ノートとタイマー付きの発表者用コンソール、客席用フルスクリーン表示の 2 ウィンドウが同期します。",
-  "howitworks_step3_title": "落ち着いて発表する",
-  "howitworks_step3_body": "ノート・タイマー・レーザーポインタ・ペン・ブラックアウトをキーボードで操作。集中を切らしません。",
+  "howitworks_step2_body": "プレゼンター画面（ノート・タイマー付き）と客席用フルスクリーンの 2 ウィンドウが同期します。",
+  "howitworks_step3_title": "発表する",
+  "howitworks_step3_body": "ノート・タイマー・レーザーポインタ・ペン・ブラックアウトをキーボードで操作できます。",
 
   "library_eyebrow": "LIBRARY",
   "library_subtitle_with_count": "{count} 件 · 新しい順",

--- a/src/routes/$locale/(main)/-index/HeroSection.tsx
+++ b/src/routes/$locale/(main)/-index/HeroSection.tsx
@@ -47,9 +47,6 @@ export function HeroSection({
 	return (
 		<section className="grid w-full grid-cols-1 gap-10 lg:grid-cols-[1.2fr_1fr] lg:gap-14">
 			<div className="flex flex-col justify-center">
-				<div className="mb-4 font-mono text-[11px] font-medium uppercase tracking-[0.14em] text-accent">
-					{m.hero_eyebrow()}
-				</div>
 				<h1 className="mb-5 text-4xl font-semibold leading-[1.05] tracking-[-0.035em] text-fg sm:text-5xl lg:text-[56px]">
 					{m.hero_headline_line1()}
 					<br />

--- a/src/vite-plugins/locale-html-plugin.ts
+++ b/src/vite-plugins/locale-html-plugin.ts
@@ -15,12 +15,12 @@ const LOCALE_CONFIGS: LocaleConfig[] = [
 
 const META = {
 	en: {
-		title: "PDFPW — Precise PDF presenter",
+		title: "pdfpw — pdfpc in your browser",
 		description:
 			"Browser-based PDF presenter console (pdfpc-compatible). No install, no upload.",
 	},
 	ja: {
-		title: "PDFPW — 精密設計のプレゼンタコンソール",
+		title: "pdfpw — ブラウザで動く pdfpc",
 		description:
 			"ブラウザベースの PDF プレゼンテーション・コンソール (pdfpc 互換)。インストール不要、アップロード不要。",
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -164,8 +164,8 @@ export default defineConfig({
 				"og-image.png",
 			],
 			manifest: {
-				name: "PDF Presenter Web",
-				short_name: "PDFPW",
+				name: "pdfpw",
+				short_name: "pdfpw",
 				description: "Browser-based PDF presenter console (pdfpc-compatible).",
 				start_url: "/",
 				scope: "/",


### PR DESCRIPTION
## Summary

- 製品名を `PDFPW` → `pdfpw`（全小文字）に統一（`index.html`, `locale-html-plugin.ts`, メッセージファイル）
- ヒーローセクションの eyebrow を削除、ヘッドラインを `pdfpc, / in your browser.` に変更
- hero lead を簡潔化（冗長な「PDF はあなたの端末から離れません」を削除）
- How It Works の各ステップタイトル・本文をマーケティング的な表現から淡々とした機能説明に変更

## Test plan

- [ ] `pnpm dev` でトップページ（EN/JA）のヒーローと How It Works を目視確認
- [ ] ブラウザタブのタイトルが `pdfpw — pdfpc in your browser` になっていることを確認
- [ ] `pnpm tsc -b` が通ること（確認済み）
- [ ] `pnpm lint` が通ること（確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)