### PR TITLE
feat: Typst ファイルを入力として受け付ける (#12)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -145,5 +145,15 @@
   "update_reload": "Reload",
 
   "license_label_license": "License",
-  "license_label_author": "Author"
+  "license_label_author": "Author",
+
+  "typst_status_loading_wasm": "Loading Typst engine…",
+  "typst_status_fetching_packages": "Fetching Typst package: {package}",
+  "typst_status_compiling": "Compiling Typst…",
+  "typst_error_no_main": "Could not find a Typst main file (main.typ)",
+  "typst_error_compile_failed": "Typst compile failed ({count} errors)",
+  "typst_error_runtime_init": "Failed to initialize Typst engine",
+  "typst_error_timeout": "Typst compilation timed out",
+  "typst_diag_severity_error": "error",
+  "typst_diag_severity_warning": "warning"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -145,5 +145,15 @@
   "update_reload": "再読み込み",
 
   "license_label_license": "ライセンス",
-  "license_label_author": "作者"
+  "license_label_author": "作者",
+
+  "typst_status_loading_wasm": "Typst エンジンを読み込み中…",
+  "typst_status_fetching_packages": "Typst パッケージを取得中: {package}",
+  "typst_status_compiling": "Typst をコンパイル中…",
+  "typst_error_no_main": "Typst の主ファイル (main.typ) が見つかりません",
+  "typst_error_compile_failed": "Typst のコンパイルに失敗しました ({count} 件のエラー)",
+  "typst_error_runtime_init": "Typst エンジンの初期化に失敗しました",
+  "typst_error_timeout": "Typst のコンパイルがタイムアウトしました",
+  "typst_diag_severity_error": "エラー",
+  "typst_diag_severity_warning": "警告"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@fontsource/geist-mono": "^5.2.7",
     "@fontsource/geist-sans": "^5.2.5",
+    "@myriaddreamin/typst-ts-web-compiler": "^0.6.0",
+    "@myriaddreamin/typst.ts": "^0.6.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@fontsource/geist-sans':
         specifier: ^5.2.5
         version: 5.2.5
+      '@myriaddreamin/typst-ts-web-compiler':
+        specifier: ^0.6.0
+        version: 0.6.0
+      '@myriaddreamin/typst.ts':
+        specifier: ^0.6.0
+        version: 0.6.0(@myriaddreamin/typst-ts-web-compiler@0.6.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1072,6 +1078,20 @@ packages:
 
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
+
+  '@myriaddreamin/typst-ts-web-compiler@0.6.0':
+    resolution: {integrity: sha512-P/eIJ5RnfElj0NYzn5PI296t/IwWtgqUyyTMi5Jm5X3V5kZfskkH+LI7mSQe8tEyxwgCvxbxvFe5adinA3K8Gg==}
+
+  '@myriaddreamin/typst.ts@0.6.0':
+    resolution: {integrity: sha512-IUpetG0NyF2H6eXRm4j+NsbanJHIvyrffHEijqYb6q128sLWQgT1FYJS+h7dtjXmrBEfnIl1mI80DyfDR6kB/w==}
+    peerDependencies:
+      '@myriaddreamin/typst-ts-renderer': ^0.6.0
+      '@myriaddreamin/typst-ts-web-compiler': ^0.6.0
+    peerDependenciesMeta:
+      '@myriaddreamin/typst-ts-renderer':
+        optional: true
+      '@myriaddreamin/typst-ts-web-compiler':
+        optional: true
 
   '@napi-rs/canvas-android-arm64@0.1.99':
     resolution: {integrity: sha512-9OCRt8VVxA17m32NWZKyNC2qamdaS/SC5CEOIQwFngRq0DIeVm4PDal+6Ljnhqm2whZiC63DNuKZ4xSp2nbj9w==}
@@ -4906,6 +4926,14 @@ snapshots:
       - babel-plugin-macros
 
   '@lix-js/server-protocol-schema@0.1.1': {}
+
+  '@myriaddreamin/typst-ts-web-compiler@0.6.0': {}
+
+  '@myriaddreamin/typst.ts@0.6.0(@myriaddreamin/typst-ts-web-compiler@0.6.0)':
+    dependencies:
+      idb: 7.1.1
+    optionalDependencies:
+      '@myriaddreamin/typst-ts-web-compiler': 0.6.0
 
   '@napi-rs/canvas-android-arm64@0.1.99':
     optional: true

--- a/src/components/TypstDiagnosticList.test.tsx
+++ b/src/components/TypstDiagnosticList.test.tsx
@@ -4,14 +4,28 @@ import type { TypstDiagnostic } from "#src/lib/typst";
 import { TypstDiagnosticList } from "./TypstDiagnosticList";
 
 describe("TypstDiagnosticList", () => {
-  it("renders one row per diagnostic with file:line:col and message", async () => {
-    const items: TypstDiagnostic[] = [
-      { severity: "error", path: "main.typ", line: 12, column: 5, message: "unknown variable: foo" },
-      { severity: "warning", path: "main.typ", line: 20, column: 1, message: "deprecated" },
-    ];
-    const screen = await render(<TypstDiagnosticList items={items} />);
-    await expect.element(screen.getByText("main.typ:12:5")).toBeVisible();
-    await expect.element(screen.getByText("unknown variable: foo")).toBeVisible();
-    await expect.element(screen.getByText("main.typ:20:1")).toBeVisible();
-  });
+	it("renders one row per diagnostic with file:line:col and message", async () => {
+		const items: TypstDiagnostic[] = [
+			{
+				severity: "error",
+				path: "main.typ",
+				line: 12,
+				column: 5,
+				message: "unknown variable: foo",
+			},
+			{
+				severity: "warning",
+				path: "main.typ",
+				line: 20,
+				column: 1,
+				message: "deprecated",
+			},
+		];
+		const screen = await render(<TypstDiagnosticList items={items} />);
+		await expect.element(screen.getByText("main.typ:12:5")).toBeVisible();
+		await expect
+			.element(screen.getByText("unknown variable: foo"))
+			.toBeVisible();
+		await expect.element(screen.getByText("main.typ:20:1")).toBeVisible();
+	});
 });

--- a/src/components/TypstDiagnosticList.test.tsx
+++ b/src/components/TypstDiagnosticList.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "vitest-browser-react";
+import { describe, expect, it } from "vitest";
+import type { TypstDiagnostic } from "#src/lib/typst";
+import { TypstDiagnosticList } from "./TypstDiagnosticList";
+
+describe("TypstDiagnosticList", () => {
+  it("renders one row per diagnostic with file:line:col and message", async () => {
+    const items: TypstDiagnostic[] = [
+      { severity: "error", path: "main.typ", line: 12, column: 5, message: "unknown variable: foo" },
+      { severity: "warning", path: "main.typ", line: 20, column: 1, message: "deprecated" },
+    ];
+    const screen = await render(<TypstDiagnosticList items={items} />);
+    await expect.element(screen.getByText("main.typ:12:5")).toBeVisible();
+    await expect.element(screen.getByText("unknown variable: foo")).toBeVisible();
+    await expect.element(screen.getByText("main.typ:20:1")).toBeVisible();
+  });
+});

--- a/src/components/TypstDiagnosticList.tsx
+++ b/src/components/TypstDiagnosticList.tsx
@@ -4,42 +4,44 @@ import { cn } from "#src/lib/utils";
 import * as m from "#src/paraglide/messages.js";
 
 interface Props {
-  items: TypstDiagnostic[];
-  max?: number;
+	items: TypstDiagnostic[];
+	max?: number;
 }
 
 export function TypstDiagnosticList({ items, max = 20 }: Props) {
-  const errors = items.filter((d) => d.severity === "error").length;
-  const shown = items.slice(0, max);
-  const remaining = items.length - shown.length;
-  return (
-    <div className="mt-4 flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-[12px]">
-      <div className="font-medium text-destructive">
-        {m.typst_error_compile_failed({ count: String(errors) })}
-      </div>
-      <ul className="flex flex-col gap-1 font-mono text-fg/80">
-        {shown.map((d, i) => (
-          <li
-            key={`${d.path}:${d.line}:${d.column}:${d.message}:${i}`}
-            className="flex items-start gap-2"
-          >
-            {d.severity === "error" ? (
-              <AlertCircleIcon className="mt-[2px] size-3.5 shrink-0 text-destructive" />
-            ) : (
-              <AlertTriangleIcon className="mt-[2px] size-3.5 shrink-0 text-amber-500" />
-            )}
-            <span className="shrink-0 text-muted">
-              {d.path}:{d.line}:{d.column}
-            </span>
-            <span className={cn(d.severity === "error" ? "text-fg" : "text-muted")}>
-              {d.message}
-            </span>
-          </li>
-        ))}
-      </ul>
-      {remaining > 0 && (
-        <div className="text-[11px] text-muted">+ {remaining} more</div>
-      )}
-    </div>
-  );
+	const errors = items.filter((d) => d.severity === "error").length;
+	const shown = items.slice(0, max);
+	const remaining = items.length - shown.length;
+	return (
+		<div className="mt-4 flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-[12px]">
+			<div className="font-medium text-destructive">
+				{m.typst_error_compile_failed({ count: String(errors) })}
+			</div>
+			<ul className="flex flex-col gap-1 font-mono text-fg/80">
+				{shown.map((d, i) => (
+					<li
+						key={`${d.path}:${d.line}:${d.column}:${d.message}:${i}`}
+						className="flex items-start gap-2"
+					>
+						{d.severity === "error" ? (
+							<AlertCircleIcon className="mt-[2px] size-3.5 shrink-0 text-destructive" />
+						) : (
+							<AlertTriangleIcon className="mt-[2px] size-3.5 shrink-0 text-warning" />
+						)}
+						<span className="shrink-0 text-muted">
+							{d.path}:{d.line}:{d.column}
+						</span>
+						<span
+							className={cn(d.severity === "error" ? "text-fg" : "text-muted")}
+						>
+							{d.message}
+						</span>
+					</li>
+				))}
+			</ul>
+			{remaining > 0 && (
+				<div className="text-[11px] text-muted">+ {remaining} more</div>
+			)}
+		</div>
+	);
 }

--- a/src/components/TypstDiagnosticList.tsx
+++ b/src/components/TypstDiagnosticList.tsx
@@ -1,0 +1,42 @@
+import { AlertCircleIcon, AlertTriangleIcon } from "lucide-react";
+import type { TypstDiagnostic } from "#src/lib/typst";
+import { cn } from "#src/lib/utils";
+import * as m from "#src/paraglide/messages.js";
+
+interface Props {
+  items: TypstDiagnostic[];
+  max?: number;
+}
+
+export function TypstDiagnosticList({ items, max = 20 }: Props) {
+  const errors = items.filter((d) => d.severity === "error").length;
+  const shown = items.slice(0, max);
+  const remaining = items.length - shown.length;
+  return (
+    <div className="mt-4 flex flex-col gap-1 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-[12px]">
+      <div className="font-medium text-destructive">
+        {m.typst_error_compile_failed({ count: String(errors) })}
+      </div>
+      <ul className="flex flex-col gap-1 font-mono text-fg/80">
+        {shown.map((d, i) => (
+          <li key={i} className="flex items-start gap-2">
+            {d.severity === "error" ? (
+              <AlertCircleIcon className="mt-[2px] size-3.5 shrink-0 text-destructive" />
+            ) : (
+              <AlertTriangleIcon className="mt-[2px] size-3.5 shrink-0 text-amber-500" />
+            )}
+            <span className="shrink-0 text-muted">
+              {d.path}:{d.line}:{d.column}
+            </span>
+            <span className={cn(d.severity === "error" ? "text-fg" : "text-muted")}>
+              {d.message}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {remaining > 0 && (
+        <div className="text-[11px] text-muted">+ {remaining} more</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TypstDiagnosticList.tsx
+++ b/src/components/TypstDiagnosticList.tsx
@@ -19,7 +19,10 @@ export function TypstDiagnosticList({ items, max = 20 }: Props) {
       </div>
       <ul className="flex flex-col gap-1 font-mono text-fg/80">
         {shown.map((d, i) => (
-          <li key={i} className="flex items-start gap-2">
+          <li
+            key={`${d.path}:${d.line}:${d.column}:${d.message}:${i}`}
+            className="flex items-start gap-2"
+          >
             {d.severity === "error" ? (
               <AlertCircleIcon className="mt-[2px] size-3.5 shrink-0 text-destructive" />
             ) : (

--- a/src/lib/recent-store.ts
+++ b/src/lib/recent-store.ts
@@ -1,16 +1,35 @@
 import { type DBSchema, type IDBPDatabase, openDB } from "idb";
 
-export type RecentFile = {
+export interface RecentPdfFile {
+	kind?: "pdf";
 	id: string;
 	name: string;
-	lastOpened: number;
 	handle?: FileSystemFileHandle;
 	configHandle?: FileSystemFileHandle;
 	configName?: string;
 	file?: File;
 	configFile?: File;
+	lastOpened: number;
 	thumbnail?: string;
-};
+}
+
+export interface RecentTypstFile {
+	kind: "typst";
+	id: string;
+	name: string;
+	mainPath: string;
+	handle?: FileSystemFileHandle;
+	assetHandles?: FileSystemFileHandle[];
+	file?: File;
+	assetFiles?: File[];
+	configHandle?: FileSystemFileHandle;
+	configFile?: File;
+	configName?: string;
+	lastOpened: number;
+	thumbnail?: string;
+}
+
+export type RecentFile = RecentPdfFile | RecentTypstFile;
 
 export type Settings = {
 	saveHistory: boolean;
@@ -70,14 +89,22 @@ export function openDb(): Promise<RecentDb> {
 export async function getRecentFiles(
 	db: IDBPDatabase<RecentSchema>,
 ): Promise<RecentFile[]> {
-	return db.getAll(DB_STORE);
+	const all = await db.getAll(DB_STORE);
+	// Migration: entries stored before the discriminated union had no `kind`.
+	// Treat missing `kind` as "pdf".
+	return all.map((item) =>
+		item.kind === undefined ? { ...item, kind: "pdf" as const } : item,
+	);
 }
 
 export async function getRecentFileById(
 	db: IDBPDatabase<RecentSchema>,
 	id: string,
 ): Promise<RecentFile | undefined> {
-	return db.get(DB_STORE, id);
+	const item = await db.get(DB_STORE, id);
+	if (!item) return undefined;
+	// Migration: entries stored before the discriminated union had no `kind`.
+	return item.kind === undefined ? { ...item, kind: "pdf" as const } : item;
 }
 
 export async function upsertRecent(

--- a/src/lib/typst-source-detect.test.ts
+++ b/src/lib/typst-source-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { containsTypst, filesToTypstSources, pickMainTypst, type TypstSource } from "./typst-source-detect";
+import { containsTypst, entriesToTypstSources, filesToTypstSources, pickMainTypst, type TypstSource } from "./typst-source-detect";
 
 const src = (path: string): TypstSource => ({ path, data: new Uint8Array() });
 
@@ -46,5 +46,41 @@ describe("filesToTypstSources", () => {
     const result = await filesToTypstSources([a, b]);
     expect(result.map((r) => r.path)).toEqual(["main.typ", "assets/logo.png"]);
     expect(result[1].data).toEqual(new Uint8Array([1, 2]));
+  });
+});
+
+describe("entriesToTypstSources", () => {
+  it("recursively expands directory entries with relative paths", async () => {
+    function fileEntry(name: string, content: string): any {
+      return {
+        isFile: true,
+        isDirectory: false,
+        name,
+        file: (cb: (f: File) => void) => cb(new File([content], name)),
+      };
+    }
+    function dirEntry(name: string, children: any[]): any {
+      return {
+        isFile: false,
+        isDirectory: true,
+        name,
+        createReader: () => {
+          let exhausted = false;
+          return {
+            readEntries: (cb: (e: any[]) => void) => {
+              if (exhausted) return cb([]);
+              exhausted = true;
+              cb(children);
+            },
+          };
+        },
+      };
+    }
+    const root = [
+      fileEntry("main.typ", "= Hi"),
+      dirEntry("img", [fileEntry("a.png", "x")]),
+    ];
+    const result = await entriesToTypstSources(root);
+    expect(result.map((r) => r.path).sort()).toEqual(["img/a.png", "main.typ"]);
   });
 });

--- a/src/lib/typst-source-detect.test.ts
+++ b/src/lib/typst-source-detect.test.ts
@@ -1,93 +1,103 @@
 import { describe, expect, it } from "vitest";
-import { containsTypst, entriesToTypstSources, filesToTypstSources, pickMainTypst, type TypstSource } from "./typst-source-detect";
+import {
+	containsTypst,
+	entriesToTypstSources,
+	filesToTypstSources,
+	pickMainTypst,
+	type TypstSource,
+} from "./typst-source-detect";
 
 const src = (path: string): TypstSource => ({ path, data: new Uint8Array() });
 
 describe("containsTypst", () => {
-  it("returns true when any file ends with .typ", () => {
-    expect(containsTypst([src("main.typ")])).toBe(true);
-    expect(containsTypst([src("a.pdf"), src("b.typ")])).toBe(true);
-  });
-  it("returns false otherwise", () => {
-    expect(containsTypst([src("a.pdf")])).toBe(false);
-    expect(containsTypst([])).toBe(false);
-  });
+	it("returns true when any file ends with .typ", () => {
+		expect(containsTypst([src("main.typ")])).toBe(true);
+		expect(containsTypst([src("a.pdf"), src("b.typ")])).toBe(true);
+	});
+	it("returns false otherwise", () => {
+		expect(containsTypst([src("a.pdf")])).toBe(false);
+		expect(containsTypst([])).toBe(false);
+	});
 });
 
 describe("pickMainTypst", () => {
-  it("returns the only .typ when single", () => {
-    expect(pickMainTypst([src("hello.typ")])).toBe("hello.typ");
-  });
-  it("prefers main.typ at root when multiple", () => {
-    expect(
-      pickMainTypst([src("intro.typ"), src("main.typ"), src("appendix.typ")]),
-    ).toBe("main.typ");
-  });
-  it("falls back to shallowest then alphabetical when no main.typ", () => {
-    expect(
-      pickMainTypst([
-        src("chapters/01.typ"),
-        src("chapters/02.typ"),
-        src("zoo.typ"),
-        src("alpha.typ"),
-      ]),
-    ).toBe("alpha.typ");
-  });
-  it("returns null when no .typ", () => {
-    expect(pickMainTypst([src("a.pdf")])).toBe(null);
-  });
+	it("returns the only .typ when single", () => {
+		expect(pickMainTypst([src("hello.typ")])).toBe("hello.typ");
+	});
+	it("prefers main.typ at root when multiple", () => {
+		expect(
+			pickMainTypst([src("intro.typ"), src("main.typ"), src("appendix.typ")]),
+		).toBe("main.typ");
+	});
+	it("falls back to shallowest then alphabetical when no main.typ", () => {
+		expect(
+			pickMainTypst([
+				src("chapters/01.typ"),
+				src("chapters/02.typ"),
+				src("zoo.typ"),
+				src("alpha.typ"),
+			]),
+		).toBe("alpha.typ");
+	});
+	it("returns null when no .typ", () => {
+		expect(pickMainTypst([src("a.pdf")])).toBe(null);
+	});
 });
 
 describe("filesToTypstSources", () => {
-  it("uses webkitRelativePath when present, otherwise file name", async () => {
-    const a = new File(["hello"], "main.typ", { type: "text/plain" });
-    const b = new File([new Uint8Array([1, 2])], "logo.png");
-    Object.defineProperty(b, "webkitRelativePath", { value: "assets/logo.png" });
-    const result = await filesToTypstSources([a, b]);
-    expect(result.map((r) => r.path)).toEqual(["main.typ", "assets/logo.png"]);
-    expect(result[1].data).toEqual(new Uint8Array([1, 2]));
-  });
+	it("uses webkitRelativePath when present, otherwise file name", async () => {
+		const a = new File(["hello"], "main.typ", { type: "text/plain" });
+		const b = new File([new Uint8Array([1, 2])], "logo.png");
+		Object.defineProperty(b, "webkitRelativePath", {
+			value: "assets/logo.png",
+		});
+		const result = await filesToTypstSources([a, b]);
+		expect(result.map((r) => r.path)).toEqual(["main.typ", "assets/logo.png"]);
+		expect(result[1].data).toEqual(new Uint8Array([1, 2]));
+	});
 });
 
 describe("entriesToTypstSources", () => {
-  it("recursively expands directory entries with relative paths", async () => {
-    type MockEntry = {
-      isFile: boolean;
-      isDirectory: boolean;
-      name: string;
-      file?: (cb: (f: File) => void) => void;
-      createReader?: () => { readEntries: (cb: (e: MockEntry[]) => void) => void };
-    };
-    function fileEntry(name: string, content: string): MockEntry {
-      return {
-        isFile: true,
-        isDirectory: false,
-        name,
-        file: (cb: (f: File) => void) => cb(new File([content], name)),
-      };
-    }
-    function dirEntry(name: string, children: MockEntry[]): MockEntry {
-      return {
-        isFile: false,
-        isDirectory: true,
-        name,
-        createReader: () => {
-          let exhausted = false;
-          return {
-            readEntries: (cb: (e: MockEntry[]) => void) => {
-              if (exhausted) return cb([]);
-              exhausted = true;
-              cb(children);
-            },
-          };
-        },
-      };
-    }
-    const root = [
-      fileEntry("main.typ", "= Hi"),
-      dirEntry("img", [fileEntry("a.png", "x")]),
-    ];
-    const result = await entriesToTypstSources(root);
-    expect(result.map((r) => r.path).sort()).toEqual(["img/a.png", "main.typ"]);
-  });
+	it("recursively expands directory entries with relative paths", async () => {
+		type MockEntry = {
+			isFile: boolean;
+			isDirectory: boolean;
+			name: string;
+			file?: (cb: (f: File) => void) => void;
+			createReader?: () => {
+				readEntries: (cb: (e: MockEntry[]) => void) => void;
+			};
+		};
+		function fileEntry(name: string, content: string): MockEntry {
+			return {
+				isFile: true,
+				isDirectory: false,
+				name,
+				file: (cb: (f: File) => void) => cb(new File([content], name)),
+			};
+		}
+		function dirEntry(name: string, children: MockEntry[]): MockEntry {
+			return {
+				isFile: false,
+				isDirectory: true,
+				name,
+				createReader: () => {
+					let exhausted = false;
+					return {
+						readEntries: (cb: (e: MockEntry[]) => void) => {
+							if (exhausted) return cb([]);
+							exhausted = true;
+							cb(children);
+						},
+					};
+				},
+			};
+		}
+		const root = [
+			fileEntry("main.typ", "= Hi"),
+			dirEntry("img", [fileEntry("a.png", "x")]),
+		];
+		const result = await entriesToTypstSources(root);
+		expect(result.map((r) => r.path).sort()).toEqual(["img/a.png", "main.typ"]);
+	});
 });

--- a/src/lib/typst-source-detect.test.ts
+++ b/src/lib/typst-source-detect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { containsTypst, pickMainTypst, type TypstSource } from "./typst-source-detect";
+import { containsTypst, filesToTypstSources, pickMainTypst, type TypstSource } from "./typst-source-detect";
 
 const src = (path: string): TypstSource => ({ path, data: new Uint8Array() });
 
@@ -35,5 +35,16 @@ describe("pickMainTypst", () => {
   });
   it("returns null when no .typ", () => {
     expect(pickMainTypst([src("a.pdf")])).toBe(null);
+  });
+});
+
+describe("filesToTypstSources", () => {
+  it("uses webkitRelativePath when present, otherwise file name", async () => {
+    const a = new File(["hello"], "main.typ", { type: "text/plain" });
+    const b = new File([new Uint8Array([1, 2])], "logo.png");
+    Object.defineProperty(b, "webkitRelativePath", { value: "assets/logo.png" });
+    const result = await filesToTypstSources([a, b]);
+    expect(result.map((r) => r.path)).toEqual(["main.typ", "assets/logo.png"]);
+    expect(result[1].data).toEqual(new Uint8Array([1, 2]));
   });
 });

--- a/src/lib/typst-source-detect.test.ts
+++ b/src/lib/typst-source-detect.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { containsTypst, pickMainTypst, type TypstSource } from "./typst-source-detect";
+
+const src = (path: string): TypstSource => ({ path, data: new Uint8Array() });
+
+describe("containsTypst", () => {
+  it("returns true when any file ends with .typ", () => {
+    expect(containsTypst([src("main.typ")])).toBe(true);
+    expect(containsTypst([src("a.pdf"), src("b.typ")])).toBe(true);
+  });
+  it("returns false otherwise", () => {
+    expect(containsTypst([src("a.pdf")])).toBe(false);
+    expect(containsTypst([])).toBe(false);
+  });
+});
+
+describe("pickMainTypst", () => {
+  it("returns the only .typ when single", () => {
+    expect(pickMainTypst([src("hello.typ")])).toBe("hello.typ");
+  });
+  it("prefers main.typ at root when multiple", () => {
+    expect(
+      pickMainTypst([src("intro.typ"), src("main.typ"), src("appendix.typ")]),
+    ).toBe("main.typ");
+  });
+  it("falls back to shallowest then alphabetical when no main.typ", () => {
+    expect(
+      pickMainTypst([
+        src("chapters/01.typ"),
+        src("chapters/02.typ"),
+        src("zoo.typ"),
+        src("alpha.typ"),
+      ]),
+    ).toBe("alpha.typ");
+  });
+  it("returns null when no .typ", () => {
+    expect(pickMainTypst([src("a.pdf")])).toBe(null);
+  });
+});

--- a/src/lib/typst-source-detect.test.ts
+++ b/src/lib/typst-source-detect.test.ts
@@ -51,7 +51,14 @@ describe("filesToTypstSources", () => {
 
 describe("entriesToTypstSources", () => {
   it("recursively expands directory entries with relative paths", async () => {
-    function fileEntry(name: string, content: string): any {
+    type MockEntry = {
+      isFile: boolean;
+      isDirectory: boolean;
+      name: string;
+      file?: (cb: (f: File) => void) => void;
+      createReader?: () => { readEntries: (cb: (e: MockEntry[]) => void) => void };
+    };
+    function fileEntry(name: string, content: string): MockEntry {
       return {
         isFile: true,
         isDirectory: false,
@@ -59,7 +66,7 @@ describe("entriesToTypstSources", () => {
         file: (cb: (f: File) => void) => cb(new File([content], name)),
       };
     }
-    function dirEntry(name: string, children: any[]): any {
+    function dirEntry(name: string, children: MockEntry[]): MockEntry {
       return {
         isFile: false,
         isDirectory: true,
@@ -67,7 +74,7 @@ describe("entriesToTypstSources", () => {
         createReader: () => {
           let exhausted = false;
           return {
-            readEntries: (cb: (e: any[]) => void) => {
+            readEntries: (cb: (e: MockEntry[]) => void) => {
               if (exhausted) return cb([]);
               exhausted = true;
               cb(children);

--- a/src/lib/typst-source-detect.ts
+++ b/src/lib/typst-source-detect.ts
@@ -25,3 +25,12 @@ export function pickMainTypst(sources: TypstSource[]): string | null {
   });
   return sorted[0].path;
 }
+
+export async function filesToTypstSources(files: File[]): Promise<TypstSource[]> {
+  return Promise.all(
+    files.map(async (f) => ({
+      path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || f.name,
+      data: new Uint8Array(await f.arrayBuffer()),
+    })),
+  );
+}

--- a/src/lib/typst-source-detect.ts
+++ b/src/lib/typst-source-detect.ts
@@ -26,6 +26,54 @@ export function pickMainTypst(sources: TypstSource[]): string | null {
   return sorted[0].path;
 }
 
+type FsEntry = {
+  isFile: boolean;
+  isDirectory: boolean;
+  name: string;
+  file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void;
+  createReader?: () => {
+    readEntries: (cb: (entries: FsEntry[]) => void, err?: (e: unknown) => void) => void;
+  };
+};
+
+function readDirAll(
+  reader: ReturnType<NonNullable<FsEntry["createReader"]>>,
+): Promise<FsEntry[]> {
+  return new Promise((resolve, reject) => {
+    const all: FsEntry[] = [];
+    const pump = () =>
+      reader.readEntries((batch) => {
+        if (batch.length === 0) return resolve(all);
+        all.push(...batch);
+        pump();
+      }, reject);
+    pump();
+  });
+}
+
+async function entryToSources(entry: FsEntry, prefix: string): Promise<TypstSource[]> {
+  const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+  if (entry.isFile && entry.file) {
+    const file = await new Promise<File>((res, rej) => entry.file!(res, rej));
+    return [{ path, data: new Uint8Array(await file.arrayBuffer()) }];
+  }
+  if (entry.isDirectory && entry.createReader) {
+    const reader = entry.createReader();
+    const children = await readDirAll(reader);
+    const nested = await Promise.all(children.map((c) => entryToSources(c, path)));
+    return nested.flat();
+  }
+  return [];
+}
+
+export async function entriesToTypstSources(
+  entries: ReadonlyArray<FsEntry | null>,
+): Promise<TypstSource[]> {
+  const filtered = entries.filter((e): e is FsEntry => !!e);
+  const nested = await Promise.all(filtered.map((e) => entryToSources(e, "")));
+  return nested.flat();
+}
+
 export async function filesToTypstSources(files: File[]): Promise<TypstSource[]> {
   return Promise.all(
     files.map(async (f) => ({

--- a/src/lib/typst-source-detect.ts
+++ b/src/lib/typst-source-detect.ts
@@ -1,0 +1,27 @@
+export interface TypstSource {
+  /** Project-root-relative path with no leading slash. e.g. "main.typ", "images/logo.png" */
+  path: string;
+  data: Uint8Array;
+}
+
+export function containsTypst(sources: TypstSource[]): boolean {
+  return sources.some((s) => /\.typ$/i.test(s.path));
+}
+
+function depth(path: string): number {
+  return path.split("/").length;
+}
+
+export function pickMainTypst(sources: TypstSource[]): string | null {
+  const typs = sources.filter((s) => /\.typ$/i.test(s.path));
+  if (typs.length === 0) return null;
+  if (typs.length === 1) return typs[0].path;
+  const root = typs.find((s) => s.path.toLowerCase() === "main.typ");
+  if (root) return root.path;
+  const sorted = [...typs].sort((a, b) => {
+    const d = depth(a.path) - depth(b.path);
+    if (d !== 0) return d;
+    return a.path.localeCompare(b.path);
+  });
+  return sorted[0].path;
+}

--- a/src/lib/typst-source-detect.ts
+++ b/src/lib/typst-source-detect.ts
@@ -1,84 +1,122 @@
 export interface TypstSource {
-  /** Project-root-relative path with no leading slash. e.g. "main.typ", "images/logo.png" */
-  path: string;
-  data: Uint8Array;
+	/** Project-root-relative path with no leading slash. e.g. "main.typ", "images/logo.png" */
+	path: string;
+	data: Uint8Array;
 }
 
-export function containsTypst(sources: TypstSource[]): boolean {
-  return sources.some((s) => /\.typ$/i.test(s.path));
+/**
+ * Path-only view of a Typst input. `containsTypst` and `pickMainTypst` only
+ * need the path; this lets callers decide whether to load the bytes (which is
+ * costly for large PDF decks that pass through the same `handleFiles` entry).
+ */
+export interface TypstSourceMeta {
+	path: string;
+}
+
+export function containsTypst(
+	sources: ReadonlyArray<TypstSourceMeta>,
+): boolean {
+	return sources.some((s) => /\.typ$/i.test(s.path));
 }
 
 function depth(path: string): number {
-  return path.split("/").length;
+	return path.split("/").length;
 }
 
-export function pickMainTypst(sources: TypstSource[]): string | null {
-  const typs = sources.filter((s) => /\.typ$/i.test(s.path));
-  if (typs.length === 0) return null;
-  if (typs.length === 1) return typs[0].path;
-  const root = typs.find((s) => s.path.toLowerCase() === "main.typ");
-  if (root) return root.path;
-  const sorted = [...typs].sort((a, b) => {
-    const d = depth(a.path) - depth(b.path);
-    if (d !== 0) return d;
-    return a.path.localeCompare(b.path);
-  });
-  return sorted[0].path;
+export function pickMainTypst(
+	sources: ReadonlyArray<TypstSourceMeta>,
+): string | null {
+	const typs = sources.filter((s) => /\.typ$/i.test(s.path));
+	if (typs.length === 0) return null;
+	if (typs.length === 1) return typs[0].path;
+	const root = typs.find((s) => s.path.toLowerCase() === "main.typ");
+	if (root) return root.path;
+	const sorted = [...typs].sort((a, b) => {
+		const d = depth(a.path) - depth(b.path);
+		if (d !== 0) return d;
+		return a.path.localeCompare(b.path);
+	});
+	return sorted[0].path;
 }
 
 type FsEntry = {
-  isFile: boolean;
-  isDirectory: boolean;
-  name: string;
-  file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void;
-  createReader?: () => {
-    readEntries: (cb: (entries: FsEntry[]) => void, err?: (e: unknown) => void) => void;
-  };
+	isFile: boolean;
+	isDirectory: boolean;
+	name: string;
+	file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void;
+	createReader?: () => {
+		readEntries: (
+			cb: (entries: FsEntry[]) => void,
+			err?: (e: unknown) => void,
+		) => void;
+	};
 };
 
 function readDirAll(
-  reader: ReturnType<NonNullable<FsEntry["createReader"]>>,
+	reader: ReturnType<NonNullable<FsEntry["createReader"]>>,
 ): Promise<FsEntry[]> {
-  return new Promise((resolve, reject) => {
-    const all: FsEntry[] = [];
-    const pump = () =>
-      reader.readEntries((batch) => {
-        if (batch.length === 0) return resolve(all);
-        all.push(...batch);
-        pump();
-      }, reject);
-    pump();
-  });
+	return new Promise((resolve, reject) => {
+		const all: FsEntry[] = [];
+		const pump = () =>
+			reader.readEntries((batch) => {
+				if (batch.length === 0) return resolve(all);
+				all.push(...batch);
+				pump();
+			}, reject);
+		pump();
+	});
 }
 
-async function entryToSources(entry: FsEntry, prefix: string): Promise<TypstSource[]> {
-  const path = prefix ? `${prefix}/${entry.name}` : entry.name;
-  if (entry.isFile && entry.file) {
-    const file = await new Promise<File>((res, rej) => entry.file!(res, rej));
-    return [{ path, data: new Uint8Array(await file.arrayBuffer()) }];
-  }
-  if (entry.isDirectory && entry.createReader) {
-    const reader = entry.createReader();
-    const children = await readDirAll(reader);
-    const nested = await Promise.all(children.map((c) => entryToSources(c, path)));
-    return nested.flat();
-  }
-  return [];
+async function entryToSources(
+	entry: FsEntry,
+	prefix: string,
+): Promise<TypstSource[]> {
+	const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+	if (entry.isFile && entry.file) {
+		const file = await new Promise<File>((res, rej) => entry.file!(res, rej));
+		return [{ path, data: new Uint8Array(await file.arrayBuffer()) }];
+	}
+	if (entry.isDirectory && entry.createReader) {
+		const reader = entry.createReader();
+		const children = await readDirAll(reader);
+		const nested = await Promise.all(
+			children.map((c) => entryToSources(c, path)),
+		);
+		return nested.flat();
+	}
+	return [];
 }
 
 export async function entriesToTypstSources(
-  entries: ReadonlyArray<FsEntry | null>,
+	entries: ReadonlyArray<FsEntry | null>,
 ): Promise<TypstSource[]> {
-  const filtered = entries.filter((e): e is FsEntry => !!e);
-  const nested = await Promise.all(filtered.map((e) => entryToSources(e, "")));
-  return nested.flat();
+	const filtered = entries.filter((e): e is FsEntry => !!e);
+	const nested = await Promise.all(filtered.map((e) => entryToSources(e, "")));
+	return nested.flat();
 }
 
-export async function filesToTypstSources(files: File[]): Promise<TypstSource[]> {
-  return Promise.all(
-    files.map(async (f) => ({
-      path: (f as File & { webkitRelativePath?: string }).webkitRelativePath || f.name,
-      data: new Uint8Array(await f.arrayBuffer()),
-    })),
-  );
+/**
+ * Cheap path-only view of `File[]`. Use this for `containsTypst` /
+ * `pickMainTypst` checks before deciding whether to materialize the bytes
+ * via `filesToTypstSources`.
+ */
+export function filesToTypstMeta(files: File[]): TypstSourceMeta[] {
+	return files.map((f) => ({
+		path:
+			(f as File & { webkitRelativePath?: string }).webkitRelativePath ||
+			f.name,
+	}));
+}
+
+export async function filesToTypstSources(
+	files: File[],
+): Promise<TypstSource[]> {
+	return Promise.all(
+		files.map(async (f) => ({
+			path:
+				(f as File & { webkitRelativePath?: string }).webkitRelativePath ||
+				f.name,
+			data: new Uint8Array(await f.arrayBuffer()),
+		})),
+	);
 }

--- a/src/lib/typst.test.ts
+++ b/src/lib/typst.test.ts
@@ -4,40 +4,40 @@ import { compileTypst } from "./typst";
 const enc = (s: string) => new TextEncoder().encode(s);
 
 describe("compileTypst", () => {
-  it("compiles a minimal .typ to a PDF", async () => {
-    const res = await compileTypst({
-      sources: [{ path: "main.typ", data: enc("= Hello\nWorld") }],
-      mainPath: "main.typ",
-    });
-    expect(res.ok).toBe(true);
-    if (res.ok) {
-      expect(res.pdf.length).toBeGreaterThan(100);
-      expect(new TextDecoder().decode(res.pdf.slice(0, 5))).toBe("%PDF-");
-    }
-  }, 60_000);
+	it("compiles a minimal .typ to a PDF", async () => {
+		const res = await compileTypst({
+			sources: [{ path: "main.typ", data: enc("= Hello\nWorld") }],
+			mainPath: "main.typ",
+		});
+		expect(res.ok).toBe(true);
+		if (res.ok) {
+			expect(res.pdf.length).toBeGreaterThan(100);
+			expect(new TextDecoder().decode(res.pdf.slice(0, 5))).toBe("%PDF-");
+		}
+	}, 60_000);
 
-  it("returns diagnostics on syntax error", async () => {
-    const res = await compileTypst({
-      sources: [{ path: "main.typ", data: enc("#let x = (\n") }],
-      mainPath: "main.typ",
-    });
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.diagnostics.length).toBeGreaterThan(0);
-      expect(res.diagnostics[0].severity).toBe("error");
-    }
-  }, 60_000);
+	it("returns diagnostics on syntax error", async () => {
+		const res = await compileTypst({
+			sources: [{ path: "main.typ", data: enc("#let x = (\n") }],
+			mainPath: "main.typ",
+		});
+		expect(res.ok).toBe(false);
+		if (!res.ok) {
+			expect(res.diagnostics.length).toBeGreaterThan(0);
+			expect(res.diagnostics[0].severity).toBe("error");
+		}
+	}, 60_000);
 
-  it("emits loading-wasm progress before compiling", async () => {
-    const stages: string[] = [];
-    await compileTypst(
-      {
-        sources: [{ path: "main.typ", data: enc("= Hi") }],
-        mainPath: "main.typ",
-      },
-      { onProgress: (p) => stages.push(p.stage) },
-    );
-    expect(stages[0]).toBe("loading-wasm");
-    expect(stages).toContain("compiling");
-  }, 60_000);
+	it("emits loading-wasm progress before compiling", async () => {
+		const stages: string[] = [];
+		await compileTypst(
+			{
+				sources: [{ path: "main.typ", data: enc("= Hi") }],
+				mainPath: "main.typ",
+			},
+			{ onProgress: (p) => stages.push(p.stage) },
+		);
+		expect(stages[0]).toBe("loading-wasm");
+		expect(stages).toContain("compiling");
+	}, 60_000);
 });

--- a/src/lib/typst.test.ts
+++ b/src/lib/typst.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { compileTypst } from "./typst";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+describe("compileTypst", () => {
+  it("compiles a minimal .typ to a PDF", async () => {
+    const res = await compileTypst({
+      sources: [{ path: "main.typ", data: enc("= Hello\nWorld") }],
+      mainPath: "main.typ",
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.pdf.length).toBeGreaterThan(100);
+      expect(new TextDecoder().decode(res.pdf.slice(0, 5))).toBe("%PDF-");
+    }
+  }, 60_000);
+
+  it("returns diagnostics on syntax error", async () => {
+    const res = await compileTypst({
+      sources: [{ path: "main.typ", data: enc("#let x = (\n") }],
+      mainPath: "main.typ",
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.diagnostics.length).toBeGreaterThan(0);
+      expect(res.diagnostics[0].severity).toBe("error");
+    }
+  }, 60_000);
+
+  it("emits loading-wasm progress before compiling", async () => {
+    const stages: string[] = [];
+    await compileTypst(
+      {
+        sources: [{ path: "main.typ", data: enc("= Hi") }],
+        mainPath: "main.typ",
+      },
+      { onProgress: (p) => stages.push(p.stage) },
+    );
+    expect(stages[0]).toBe("loading-wasm");
+    expect(stages).toContain("compiling");
+  }, 60_000);
+});

--- a/src/lib/typst.ts
+++ b/src/lib/typst.ts
@@ -2,83 +2,83 @@ import type { TypstSource } from "./typst-source-detect";
 export type { TypstSource } from "./typst-source-detect";
 
 export interface TypstDiagnostic {
-  severity: "error" | "warning";
-  path: string;
-  line: number; // 1-origin
-  column: number; // 1-origin
-  message: string;
-  package?: string;
+	severity: "error" | "warning";
+	path: string;
+	line: number; // 1-origin
+	column: number; // 1-origin
+	message: string;
+	package?: string;
 }
 
 export type TypstProgress =
-  | { stage: "loading-wasm" }
-  | { stage: "fetching-packages"; current?: string }
-  | { stage: "compiling" };
+	| { stage: "loading-wasm" }
+	| { stage: "fetching-packages"; current?: string }
+	| { stage: "compiling" };
 
 export interface CompileRequest {
-  sources: TypstSource[];
-  mainPath: string;
+	sources: TypstSource[];
+	mainPath: string;
 }
 
 export type CompileResult =
-  | { ok: true; pdf: Uint8Array }
-  | { ok: false; diagnostics: TypstDiagnostic[] };
+	| { ok: true; pdf: Uint8Array }
+	| { ok: false; diagnostics: TypstDiagnostic[] };
 
 export interface CompileOptions {
-  signal?: AbortSignal;
-  onProgress?: (p: TypstProgress) => void;
+	signal?: AbortSignal;
+	onProgress?: (p: TypstProgress) => void;
 }
 
 export type WorkerInbound = { kind: "compile"; req: CompileRequest };
 export type WorkerOutbound =
-  | { kind: "progress"; payload: TypstProgress }
-  | { kind: "result"; payload: CompileResult }
-  | { kind: "fatal"; message: string };
+	| { kind: "progress"; payload: TypstProgress }
+	| { kind: "result"; payload: CompileResult }
+	| { kind: "fatal"; message: string };
 
 export function compileTypst(
-  req: CompileRequest,
-  opts: CompileOptions = {},
+	req: CompileRequest,
+	opts: CompileOptions = {},
 ): Promise<CompileResult> {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(
-      new URL("../workers/typst-worker.ts", import.meta.url),
-      { type: "module" },
-    );
-    const cleanup = () => {
-      worker.terminate();
-      opts.signal?.removeEventListener("abort", onAbort);
-    };
-    const onAbort = () => {
-      cleanup();
-      reject(new DOMException("Aborted", "AbortError"));
-    };
-    if (opts.signal) {
-      if (opts.signal.aborted) return onAbort();
-      opts.signal.addEventListener("abort", onAbort);
-    }
+	return new Promise((resolve, reject) => {
+		const worker = new Worker(
+			new URL("../workers/typst-worker.ts", import.meta.url),
+			{ type: "module" },
+		);
+		const cleanup = () => {
+			worker.terminate();
+			opts.signal?.removeEventListener("abort", onAbort);
+		};
+		const onAbort = () => {
+			cleanup();
+			reject(new DOMException("Aborted", "AbortError"));
+		};
+		if (opts.signal) {
+			if (opts.signal.aborted) return onAbort();
+			opts.signal.addEventListener("abort", onAbort);
+		}
 
-    worker.addEventListener("message", (ev: MessageEvent<WorkerOutbound>) => {
-      const msg = ev.data;
-      switch (msg.kind) {
-        case "progress":
-          opts.onProgress?.(msg.payload);
-          break;
-        case "result":
-          cleanup();
-          resolve(msg.payload);
-          break;
-        case "fatal":
-          cleanup();
-          reject(new Error(msg.message));
-          break;
-      }
-    });
-    worker.addEventListener("error", (ev) => {
-      cleanup();
-      reject(new Error(ev.message || "worker error"));
-    });
+		worker.addEventListener("message", (ev: MessageEvent<WorkerOutbound>) => {
+			const msg = ev.data;
+			switch (msg.kind) {
+				case "progress":
+					opts.onProgress?.(msg.payload);
+					break;
+				case "result":
+					cleanup();
+					resolve(msg.payload);
+					break;
+				case "fatal":
+					cleanup();
+					reject(new Error(msg.message));
+					break;
+			}
+		});
+		worker.addEventListener("error", (ev) => {
+			cleanup();
+			reject(new Error(ev.message || "worker error"));
+		});
 
-    const inbound: WorkerInbound = { kind: "compile", req };
-    worker.postMessage(inbound);
-  });
+		const inbound: WorkerInbound = { kind: "compile", req };
+		worker.postMessage(inbound);
+	});
 }

--- a/src/lib/typst.ts
+++ b/src/lib/typst.ts
@@ -34,3 +34,51 @@ export type WorkerOutbound =
   | { kind: "progress"; payload: TypstProgress }
   | { kind: "result"; payload: CompileResult }
   | { kind: "fatal"; message: string };
+
+export function compileTypst(
+  req: CompileRequest,
+  opts: CompileOptions = {},
+): Promise<CompileResult> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("../workers/typst-worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    const cleanup = () => {
+      worker.terminate();
+      opts.signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    if (opts.signal) {
+      if (opts.signal.aborted) return onAbort();
+      opts.signal.addEventListener("abort", onAbort);
+    }
+
+    worker.addEventListener("message", (ev: MessageEvent<WorkerOutbound>) => {
+      const msg = ev.data;
+      switch (msg.kind) {
+        case "progress":
+          opts.onProgress?.(msg.payload);
+          break;
+        case "result":
+          cleanup();
+          resolve(msg.payload);
+          break;
+        case "fatal":
+          cleanup();
+          reject(new Error(msg.message));
+          break;
+      }
+    });
+    worker.addEventListener("error", (ev) => {
+      cleanup();
+      reject(new Error(ev.message || "worker error"));
+    });
+
+    const inbound: WorkerInbound = { kind: "compile", req };
+    worker.postMessage(inbound);
+  });
+}

--- a/src/lib/typst.ts
+++ b/src/lib/typst.ts
@@ -1,0 +1,36 @@
+import type { TypstSource } from "./typst-source-detect";
+export type { TypstSource } from "./typst-source-detect";
+
+export interface TypstDiagnostic {
+  severity: "error" | "warning";
+  path: string;
+  line: number; // 1-origin
+  column: number; // 1-origin
+  message: string;
+  package?: string;
+}
+
+export type TypstProgress =
+  | { stage: "loading-wasm" }
+  | { stage: "fetching-packages"; current?: string }
+  | { stage: "compiling" };
+
+export interface CompileRequest {
+  sources: TypstSource[];
+  mainPath: string;
+}
+
+export type CompileResult =
+  | { ok: true; pdf: Uint8Array }
+  | { ok: false; diagnostics: TypstDiagnostic[] };
+
+export interface CompileOptions {
+  signal?: AbortSignal;
+  onProgress?: (p: TypstProgress) => void;
+}
+
+export type WorkerInbound = { kind: "compile"; req: CompileRequest };
+export type WorkerOutbound =
+  | { kind: "progress"; payload: TypstProgress }
+  | { kind: "result"; payload: CompileResult }
+  | { kind: "fatal"; message: string };

--- a/src/routes/$locale/(main)/-index/HeroSection.tsx
+++ b/src/routes/$locale/(main)/-index/HeroSection.tsx
@@ -1,8 +1,54 @@
 import { FileIcon, LinkIcon, PlayIcon, PlusIcon } from "lucide-react";
 import { type DragEvent, useId, useRef, useState } from "react";
+import type React from "react";
 import { Button } from "#src/components/ui/button";
 import { cn } from "#src/lib/utils";
 import * as m from "#src/paraglide/messages.js";
+
+type FsEntry = {
+	isFile: boolean;
+	isDirectory: boolean;
+	name: string;
+	file?: (cb: (f: File) => void, err?: (e: unknown) => void) => void;
+	createReader?: () => {
+		readEntries: (cb: (entries: FsEntry[]) => void, err?: (e: unknown) => void) => void;
+	};
+};
+
+async function expandDroppedItems(list: DataTransferItemList): Promise<File[]> {
+	const entries: FsEntry[] = [];
+	for (const it of Array.from(list)) {
+		const getEntry = (it as DataTransferItem & {
+			webkitGetAsEntry?: () => FsEntry | null;
+		}).webkitGetAsEntry;
+		if (typeof getEntry === "function") {
+			const e = getEntry.call(it);
+			if (e) entries.push(e);
+		}
+	}
+	if (entries.length === 0) return [];
+
+	const out: File[] = [];
+	async function walk(entry: FsEntry, prefix: string): Promise<void> {
+		const path = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isFile && entry.file) {
+			const file: File = await new Promise((res, rej) => entry.file!(res, rej));
+			Object.defineProperty(file, "webkitRelativePath", { value: path });
+			out.push(file);
+			return;
+		}
+		if (entry.isDirectory && entry.createReader) {
+			const reader = entry.createReader();
+			let batch: FsEntry[] = [];
+			do {
+				batch = await new Promise<FsEntry[]>((res, rej) => reader.readEntries(res, rej));
+				for (const c of batch) await walk(c, path);
+			} while (batch.length > 0);
+		}
+	}
+	for (const e of entries) await walk(e, "");
+	return out;
+}
 
 const isMac = /Macintosh|MacIntel|MacPPC|Mac68K/.test(navigator.userAgent);
 
@@ -20,7 +66,7 @@ function demoUrls(locale: string): { pdf: string; pdfpc: string } {
 }
 
 interface HeroSectionProps {
-	status: string | null;
+	status: React.ReactNode | null;
 	inputId: string;
 	supportsFSA: boolean;
 	locale: string;
@@ -45,10 +91,20 @@ export function HeroSection({
 	const [pdfpcUrlValue, setPdfpcUrlValue] = useState("");
 	const urlFormId = useId();
 
-	function handleDrop(event: DragEvent<HTMLLabelElement>) {
+	async function handleDrop(event: DragEvent<HTMLLabelElement>) {
 		event.preventDefault();
 		setDragActive(false);
-		const files = Array.from(event.dataTransfer.files);
+		const items = event.dataTransfer.items;
+		const supportsEntries =
+			items != null &&
+			Array.from(items).some(
+				(it) =>
+					typeof (it as DataTransferItem & { webkitGetAsEntry?: unknown })
+						.webkitGetAsEntry === "function",
+			);
+		const files = supportsEntries
+			? await expandDroppedItems(items)
+			: Array.from(event.dataTransfer.files);
 		if (files.length > 0) void onFilesSelected(files);
 	}
 
@@ -198,14 +254,14 @@ export function HeroSection({
 						<p className="text-[11px] text-muted">{m.hero_url_hint()}</p>
 					</form>
 				)}
-				{status && (
-					<output className="mt-6 text-[12px] text-muted">{status}</output>
+				{status !== null && status !== undefined && status !== false && (
+					<div className="mt-6 text-[12px] text-muted">{status}</div>
 				)}
 			</div>
 
 			<label
 				htmlFor={inputId}
-				onDrop={handleDrop}
+				onDrop={(e) => void handleDrop(e)}
 				onDragOver={handleDragOver}
 				onDragLeave={handleDragLeave}
 				className={cn(
@@ -232,7 +288,7 @@ export function HeroSection({
 					ref={inputRef}
 					id={inputId}
 					type="file"
-					accept=".pdf,.pdfpc,application/pdf,application/json"
+					accept=".pdf,.pdfpc,.typ,application/pdf,application/json"
 					multiple
 					onChange={handleFileChange}
 					className="sr-only"

--- a/src/routes/$locale/(main)/index.tsx
+++ b/src/routes/$locale/(main)/index.tsx
@@ -31,6 +31,7 @@ import { generateThumbnail } from "#src/lib/thumbnail";
 import { compileTypst } from "#src/lib/typst";
 import {
 	containsTypst,
+	filesToTypstMeta,
 	filesToTypstSources,
 	pickMainTypst,
 } from "#src/lib/typst-source-detect";
@@ -267,25 +268,34 @@ function Home() {
 			return basePdf.toLowerCase() === baseCfg.toLowerCase();
 		};
 
-		// Typst branch
-		const sources = await filesToTypstSources(files);
-		if (containsTypst(sources)) {
-			const mainPath = pickMainTypst(sources);
+		// Typst branch — detect by filename only first; do not eagerly read bytes.
+		// `filesToTypstSources` is async (arrayBuffer) and must NOT run on the PDF
+		// path or we double-load every PDF deck on open.
+		const meta = filesToTypstMeta(files);
+		if (containsTypst(meta)) {
+			const mainPath = pickMainTypst(meta);
 			if (!mainPath) {
 				setStatus(m.typst_error_no_main());
 				return;
 			}
 			setStatus(m.typst_status_loading_wasm());
+			const sources = await filesToTypstSources(files);
 			let result: Awaited<ReturnType<typeof compileTypst>>;
 			try {
 				result = await compileTypst(
 					{ sources, mainPath },
 					{
 						onProgress: (p) => {
-							if (p.stage === "loading-wasm") setStatus(m.typst_status_loading_wasm());
+							if (p.stage === "loading-wasm")
+								setStatus(m.typst_status_loading_wasm());
 							else if (p.stage === "fetching-packages")
-								setStatus(m.typst_status_fetching_packages({ package: p.current ?? "" }));
-							else if (p.stage === "compiling") setStatus(m.typst_status_compiling());
+								setStatus(
+									m.typst_status_fetching_packages({
+										package: p.current ?? "",
+									}),
+								);
+							else if (p.stage === "compiling")
+								setStatus(m.typst_status_compiling());
 						},
 					},
 				);
@@ -301,11 +311,21 @@ function Home() {
 				setStatus(<TypstDiagnosticList items={result.diagnostics} />);
 				return;
 			}
-			const stem = mainPath.replace(/\.typ$/i, "").split("/").pop() ?? "main";
-			const pdfArrayBuffer = new Uint8Array(result.pdf).buffer;
-			const compiledPdf = new File([pdfArrayBuffer], `${stem}.pdf`, {
-				type: "application/pdf",
-			});
+			const stem =
+				mainPath
+					.replace(/\.typ$/i, "")
+					.split("/")
+					.pop() ?? "main";
+			// Pass the underlying buffer directly to avoid an extra Uint8Array copy.
+			// Worker-cloned Uint8Array always lands with a plain ArrayBuffer
+			// (byteOffset 0, full length), so the cast is safe.
+			const compiledPdf = new File(
+				[result.pdf.buffer as ArrayBuffer],
+				`${stem}.pdf`,
+				{
+					type: "application/pdf",
+				},
+			);
 			const pdfpc = files.find(
 				(f) => /\.pdfpc$/i.test(f.name) && sameBase(`${stem}.pdf`, f.name),
 			);
@@ -319,16 +339,16 @@ function Home() {
 				(f) => f !== mainSourceFile && !/\.pdfpc$/i.test(f.name),
 			);
 			const assetHandles = handles?.filter(
-				(h) =>
-					h.name !== mainSourceFile?.name && !/\.pdfpc$/i.test(h.name),
+				(h) => h.name !== mainSourceFile?.name && !/\.pdfpc$/i.test(h.name),
 			);
 			const sourceHandle = handles?.find(
-				(h) =>
-					h.name ===
-					(mainSourceFile?.name ?? mainPath.split("/").pop()),
+				(h) => h.name === (mainSourceFile?.name ?? mainPath.split("/").pop()),
 			);
 
-			await proceedWithPdf(compiledPdf, pdfpc, undefined, {
+			// Forward `handles` so `proceedWithPdf` can resolve the pdfpc handle
+			// for FSA-based Typst recents (the synthetic compiled PDF itself has
+			// no handle, so the pdfHandle search is a harmless miss).
+			await proceedWithPdf(compiledPdf, pdfpc, handles, {
 				mainPath,
 				sourceFile: mainSourceFile,
 				assetFiles,

--- a/src/routes/$locale/(main)/index.tsx
+++ b/src/routes/$locale/(main)/index.tsx
@@ -276,17 +276,27 @@ function Home() {
 				return;
 			}
 			setStatus(m.typst_status_loading_wasm());
-			const result = await compileTypst(
-				{ sources, mainPath },
-				{
-					onProgress: (p) => {
-						if (p.stage === "loading-wasm") setStatus(m.typst_status_loading_wasm());
-						else if (p.stage === "fetching-packages")
-							setStatus(m.typst_status_fetching_packages({ package: p.current ?? "" }));
-						else if (p.stage === "compiling") setStatus(m.typst_status_compiling());
+			let result: Awaited<ReturnType<typeof compileTypst>>;
+			try {
+				result = await compileTypst(
+					{ sources, mainPath },
+					{
+						onProgress: (p) => {
+							if (p.stage === "loading-wasm") setStatus(m.typst_status_loading_wasm());
+							else if (p.stage === "fetching-packages")
+								setStatus(m.typst_status_fetching_packages({ package: p.current ?? "" }));
+							else if (p.stage === "compiling") setStatus(m.typst_status_compiling());
+						},
 					},
-				},
-			);
+				);
+			} catch (err) {
+				if ((err as Error)?.name === "AbortError") {
+					setStatus(null);
+					return;
+				}
+				setStatus(m.typst_error_runtime_init());
+				return;
+			}
 			if (!result.ok) {
 				setStatus(<TypstDiagnosticList items={result.diagnostics} />);
 				return;

--- a/src/routes/$locale/(main)/index.tsx
+++ b/src/routes/$locale/(main)/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router";
+import type React from "react";
 import {
 	Suspense,
 	startTransition,
@@ -9,6 +10,7 @@ import {
 	useState,
 } from "react";
 import * as typia from "typia";
+import { TypstDiagnosticList } from "#src/components/TypstDiagnosticList";
 import { useLocalStorageSync } from "#src/hooks/use-local-storage-sync";
 import { FetchPdfError, fetchPdfFromUrl } from "#src/lib/fetch-pdf";
 import {
@@ -26,6 +28,12 @@ import {
 	upsertRecent,
 } from "#src/lib/recent-store";
 import { generateThumbnail } from "#src/lib/thumbnail";
+import { compileTypst } from "#src/lib/typst";
+import {
+	containsTypst,
+	filesToTypstSources,
+	pickMainTypst,
+} from "#src/lib/typst-source-detect";
 import * as m from "#src/paraglide/messages.js";
 import { HeroSection } from "./-index/HeroSection";
 import { HowItWorksSection } from "./-index/HowItWorksSection";
@@ -57,7 +65,7 @@ function Home() {
 		"pdfpw-save-history",
 		true,
 	);
-	const [status, setStatus] = useState<string | null>(null);
+	const [status, setStatus] = useState<React.ReactNode | null>(null);
 	const inputId = useId();
 	const router = useRouter();
 
@@ -110,30 +118,18 @@ function Home() {
 		}
 	}
 
-	async function handleFiles(files: File[], handles?: FileSystemFileHandle[]) {
+	async function proceedWithPdf(
+		pdf: File,
+		pdfpc: File | undefined,
+		handles?: FileSystemFileHandle[],
+	) {
 		const sameBase = (pdfName: string, configName: string) => {
 			const basePdf = pdfName.replace(/\.pdf$/i, "");
 			const baseCfg = configName.replace(/\.pdfpc$/i, "");
 			return basePdf.toLowerCase() === baseCfg.toLowerCase();
 		};
 
-		const pdf = files.find(
-			(f) =>
-				f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf"),
-		);
-		const pdfpc = pdf
-			? files.find(
-					(f) => /\.pdfpc$/i.test(f.name) && sameBase(pdf.name, f.name),
-				)
-			: undefined;
-
-		if (!pdf) {
-			setStatus(m.presenter_error_no_pdf());
-			return;
-		}
-
 		const thumbnail = await generateThumbnail(pdf);
-
 		const pdfHandle = handles?.find((h) => h.name === pdf.name);
 		const pdfpcHandle =
 			pdf && pdfpc && sameBase(pdf.name, pdfpc.name)
@@ -158,7 +154,6 @@ function Home() {
 				refreshRecentFiles(db);
 			});
 		} else if (saveHistory) {
-			// Standard Mode: save snapshot
 			await saveRecent({
 				id: `snapshot-${pdf.name}-${Date.now()}`,
 				name: pdf.name,
@@ -212,6 +207,66 @@ function Home() {
 				"width=1200,height=675,resizable=yes",
 			);
 		}
+	}
+
+	async function handleFiles(files: File[], handles?: FileSystemFileHandle[]) {
+		const sameBase = (pdfName: string, configName: string) => {
+			const basePdf = pdfName.replace(/\.pdf$/i, "");
+			const baseCfg = configName.replace(/\.pdfpc$/i, "");
+			return basePdf.toLowerCase() === baseCfg.toLowerCase();
+		};
+
+		// Typst branch
+		const sources = await filesToTypstSources(files);
+		if (containsTypst(sources)) {
+			const mainPath = pickMainTypst(sources);
+			if (!mainPath) {
+				setStatus(m.typst_error_no_main());
+				return;
+			}
+			setStatus(m.typst_status_loading_wasm());
+			const result = await compileTypst(
+				{ sources, mainPath },
+				{
+					onProgress: (p) => {
+						if (p.stage === "loading-wasm") setStatus(m.typst_status_loading_wasm());
+						else if (p.stage === "fetching-packages")
+							setStatus(m.typst_status_fetching_packages({ package: p.current ?? "" }));
+						else if (p.stage === "compiling") setStatus(m.typst_status_compiling());
+					},
+				},
+			);
+			if (!result.ok) {
+				setStatus(<TypstDiagnosticList items={result.diagnostics} />);
+				return;
+			}
+			const stem = mainPath.replace(/\.typ$/i, "").split("/").pop() ?? "main";
+			const pdfArrayBuffer = new Uint8Array(result.pdf).buffer;
+			const compiledPdf = new File([pdfArrayBuffer], `${stem}.pdf`, {
+				type: "application/pdf",
+			});
+			const pdfpc = files.find(
+				(f) => /\.pdfpc$/i.test(f.name) && sameBase(`${stem}.pdf`, f.name),
+			);
+			await proceedWithPdf(compiledPdf, pdfpc);
+			return;
+		}
+
+		// PDF branch (existing behavior)
+		const pdf = files.find(
+			(f) =>
+				f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf"),
+		);
+		const pdfpc = pdf
+			? files.find(
+					(f) => /\.pdfpc$/i.test(f.name) && sameBase(pdf.name, f.name),
+				)
+			: undefined;
+		if (!pdf) {
+			setStatus(m.presenter_error_no_pdf());
+			return;
+		}
+		await proceedWithPdf(pdf, pdfpc, handles);
 	}
 
 	async function onFilesSelected(files: File[]) {

--- a/src/routes/$locale/(main)/index.tsx
+++ b/src/routes/$locale/(main)/index.tsx
@@ -122,6 +122,13 @@ function Home() {
 		pdf: File,
 		pdfpc: File | undefined,
 		handles?: FileSystemFileHandle[],
+		typstMeta?: {
+			mainPath: string;
+			sourceFile?: File;
+			assetFiles?: File[];
+			sourceHandle?: FileSystemFileHandle;
+			assetHandles?: FileSystemFileHandle[];
+		},
 	) {
 		const sameBase = (pdfName: string, configName: string) => {
 			const basePdf = pdfName.replace(/\.pdf$/i, "");
@@ -136,8 +143,51 @@ function Home() {
 				? handles?.find((h) => h.name === pdfpc.name)
 				: undefined;
 
-		if (pdfHandle && supportsFSA) {
+		if (typstMeta) {
+			const typstId =
+				typstMeta.sourceHandle?.name ??
+				`snapshot-typst-${typstMeta.sourceFile?.name ?? pdf.name}-${Date.now()}`;
+			if (typstMeta.sourceHandle && supportsFSA) {
+				await saveRecent({
+					kind: "typst",
+					id: typstId,
+					name: typstMeta.sourceHandle.name,
+					mainPath: typstMeta.mainPath,
+					handle: typstMeta.sourceHandle,
+					assetHandles: typstMeta.assetHandles,
+					configHandle: pdfpcHandle && pdfpc ? pdfpcHandle : undefined,
+					configName:
+						pdfpc && pdfpcHandle && sameBase(pdf.name, pdfpc.name)
+							? pdfpc.name
+							: undefined,
+					lastOpened: Date.now(),
+					thumbnail: thumbnail ?? undefined,
+				});
+				const db = await openDb();
+				startTransition(() => {
+					refreshRecentFiles(db);
+				});
+			} else if (saveHistory) {
+				await saveRecent({
+					kind: "typst",
+					id: typstId,
+					name: typstMeta.sourceFile?.name ?? pdf.name,
+					mainPath: typstMeta.mainPath,
+					file: typstMeta.sourceFile,
+					assetFiles: typstMeta.assetFiles,
+					configFile: pdfpc,
+					configName: pdfpc?.name,
+					lastOpened: Date.now(),
+					thumbnail: thumbnail ?? undefined,
+				});
+				const db = await openDb();
+				startTransition(() => {
+					refreshRecentFiles(db);
+				});
+			}
+		} else if (pdfHandle && supportsFSA) {
 			await saveRecent({
+				kind: "pdf",
 				id: pdfHandle.name,
 				name: pdf.name,
 				handle: pdfHandle,
@@ -155,6 +205,7 @@ function Home() {
 			});
 		} else if (saveHistory) {
 			await saveRecent({
+				kind: "pdf",
 				id: `snapshot-${pdf.name}-${Date.now()}`,
 				name: pdf.name,
 				file: pdf,
@@ -248,7 +299,32 @@ function Home() {
 			const pdfpc = files.find(
 				(f) => /\.pdfpc$/i.test(f.name) && sameBase(`${stem}.pdf`, f.name),
 			);
-			await proceedWithPdf(compiledPdf, pdfpc);
+
+			const mainSourceFile = files.find(
+				(f) =>
+					((f as File & { webkitRelativePath?: string }).webkitRelativePath ||
+						f.name) === mainPath,
+			);
+			const assetFiles = files.filter(
+				(f) => f !== mainSourceFile && !/\.pdfpc$/i.test(f.name),
+			);
+			const assetHandles = handles?.filter(
+				(h) =>
+					h.name !== mainSourceFile?.name && !/\.pdfpc$/i.test(h.name),
+			);
+			const sourceHandle = handles?.find(
+				(h) =>
+					h.name ===
+					(mainSourceFile?.name ?? mainPath.split("/").pop()),
+			);
+
+			await proceedWithPdf(compiledPdf, pdfpc, undefined, {
+				mainPath,
+				sourceFile: mainSourceFile,
+				assetFiles,
+				sourceHandle,
+				assetHandles,
+			});
 			return;
 		}
 
@@ -274,6 +350,35 @@ function Home() {
 	}
 
 	async function onRecentClick(item: RecentFile) {
+		if (item.kind === "typst") {
+			if (item.handle) {
+				const canRead = await ensureHandleReadable(item.handle);
+				if (!canRead) {
+					setStatus(m.presenter_error_permission_denied());
+					return;
+				}
+				const main = await item.handle.getFile();
+				const assets: File[] = [];
+				for (const ah of item.assetHandles ?? []) {
+					const ok = await ensureHandleReadable(ah);
+					if (ok) assets.push(await ah.getFile());
+				}
+				const cfg = item.configHandle
+					? [await item.configHandle.getFile()]
+					: [];
+				const allHandles = [item.handle, ...(item.assetHandles ?? [])];
+				if (item.configHandle) allHandles.push(item.configHandle);
+				await handleFiles([main, ...assets, ...cfg], allHandles);
+				return;
+			}
+			if (item.file) {
+				const cfg = item.configFile ? [item.configFile] : [];
+				await handleFiles([item.file, ...(item.assetFiles ?? []), ...cfg]);
+				return;
+			}
+			return;
+		}
+
 		if (item.handle) {
 			const canRead = await ensureHandleReadable(item.handle);
 			if (!canRead) {

--- a/src/workers/typst-worker.ts
+++ b/src/workers/typst-worker.ts
@@ -1,0 +1,86 @@
+import {
+  createTypstCompiler,
+  FetchPackageRegistry,
+  initOptions,
+  MemoryAccessModel,
+} from "@myriaddreamin/typst.ts";
+// Note: in typst.ts 0.6, withAccessModel/withPackageRegistry are exposed via the
+// `initOptions` namespace re-export, not as top-level named exports.
+import wasmUrl from "@myriaddreamin/typst-ts-web-compiler/wasm?url";
+import type {
+  CompileRequest,
+  CompileResult,
+  TypstDiagnostic,
+  WorkerInbound,
+  WorkerOutbound,
+} from "#src/lib/typst";
+
+const RANGE_RE = /^(\d+):(\d+)-\d+:\d+$/;
+
+function parseDiagnostic(d: {
+  package: string;
+  path: string;
+  severity: string;
+  range: string;
+  message: string;
+}): TypstDiagnostic {
+  const m = RANGE_RE.exec(d.range);
+  return {
+    severity: d.severity === "warning" ? "warning" : "error",
+    path: d.path,
+    line: m ? Number(m[1]) : 1,
+    column: m ? Number(m[2]) : 1,
+    message: d.message,
+    package: d.package || undefined,
+  };
+}
+
+function post(msg: WorkerOutbound) {
+  (self as unknown as Worker).postMessage(msg);
+}
+
+async function compile(req: CompileRequest): Promise<CompileResult> {
+  post({ kind: "progress", payload: { stage: "loading-wasm" } });
+
+  const am = new MemoryAccessModel();
+  const reg = new FetchPackageRegistry(am);
+  const compiler = createTypstCompiler();
+  await compiler.init({
+    getModule: () => fetch(wasmUrl).then((r) => r.arrayBuffer()),
+    beforeBuild: [initOptions.withAccessModel(am), initOptions.withPackageRegistry(reg)],
+  });
+
+  for (const src of req.sources) {
+    if (/\.typ$/i.test(src.path)) {
+      compiler.addSource(`/${src.path}`, new TextDecoder().decode(src.data));
+    } else {
+      compiler.mapShadow(`/${src.path}`, src.data);
+    }
+  }
+
+  // Note: typst.ts 0.6 does not expose package-fetch lifecycle events.
+  // The `fetching-packages` stage in the protocol is reserved for future use
+  // and is currently never emitted here.
+  post({ kind: "progress", payload: { stage: "compiling" } });
+  const res = await compiler.compile({
+    format: "pdf",
+    mainFilePath: `/${req.mainPath}`,
+    diagnostics: "full",
+  });
+
+  if (res.result && res.result.length > 0) {
+    return { ok: true, pdf: res.result };
+  }
+  const diagnostics = (res.diagnostics ?? []).map(parseDiagnostic);
+  return { ok: false, diagnostics };
+}
+
+self.addEventListener("message", async (ev: MessageEvent<WorkerInbound>) => {
+  if (ev.data.kind !== "compile") return;
+  try {
+    const result = await compile(ev.data.req);
+    post({ kind: "result", payload: result });
+  } catch (err) {
+    post({ kind: "fatal", message: err instanceof Error ? err.message : String(err) });
+  }
+});

--- a/src/workers/typst-worker.ts
+++ b/src/workers/typst-worker.ts
@@ -1,86 +1,92 @@
 import {
-  createTypstCompiler,
-  FetchPackageRegistry,
-  initOptions,
-  MemoryAccessModel,
+	createTypstCompiler,
+	FetchPackageRegistry,
+	initOptions,
+	MemoryAccessModel,
 } from "@myriaddreamin/typst.ts";
 // Note: in typst.ts 0.6, withAccessModel/withPackageRegistry are exposed via the
 // `initOptions` namespace re-export, not as top-level named exports.
 import wasmUrl from "@myriaddreamin/typst-ts-web-compiler/wasm?url";
 import type {
-  CompileRequest,
-  CompileResult,
-  TypstDiagnostic,
-  WorkerInbound,
-  WorkerOutbound,
+	CompileRequest,
+	CompileResult,
+	TypstDiagnostic,
+	WorkerInbound,
+	WorkerOutbound,
 } from "#src/lib/typst";
 
 const RANGE_RE = /^(\d+):(\d+)-\d+:\d+$/;
 
 function parseDiagnostic(d: {
-  package: string;
-  path: string;
-  severity: string;
-  range: string;
-  message: string;
+	package: string;
+	path: string;
+	severity: string;
+	range: string;
+	message: string;
 }): TypstDiagnostic {
-  const m = RANGE_RE.exec(d.range);
-  return {
-    severity: d.severity === "warning" ? "warning" : "error",
-    path: d.path,
-    line: m ? Number(m[1]) : 1,
-    column: m ? Number(m[2]) : 1,
-    message: d.message,
-    package: d.package || undefined,
-  };
+	const m = RANGE_RE.exec(d.range);
+	return {
+		severity: d.severity === "warning" ? "warning" : "error",
+		path: d.path,
+		line: m ? Number(m[1]) : 1,
+		column: m ? Number(m[2]) : 1,
+		message: d.message,
+		package: d.package || undefined,
+	};
 }
 
 function post(msg: WorkerOutbound) {
-  (self as unknown as Worker).postMessage(msg);
+	(self as unknown as Worker).postMessage(msg);
 }
 
 async function compile(req: CompileRequest): Promise<CompileResult> {
-  post({ kind: "progress", payload: { stage: "loading-wasm" } });
+	post({ kind: "progress", payload: { stage: "loading-wasm" } });
 
-  const am = new MemoryAccessModel();
-  const reg = new FetchPackageRegistry(am);
-  const compiler = createTypstCompiler();
-  await compiler.init({
-    getModule: () => fetch(wasmUrl).then((r) => r.arrayBuffer()),
-    beforeBuild: [initOptions.withAccessModel(am), initOptions.withPackageRegistry(reg)],
-  });
+	const am = new MemoryAccessModel();
+	const reg = new FetchPackageRegistry(am);
+	const compiler = createTypstCompiler();
+	await compiler.init({
+		getModule: () => fetch(wasmUrl).then((r) => r.arrayBuffer()),
+		beforeBuild: [
+			initOptions.withAccessModel(am),
+			initOptions.withPackageRegistry(reg),
+		],
+	});
 
-  for (const src of req.sources) {
-    if (/\.typ$/i.test(src.path)) {
-      compiler.addSource(`/${src.path}`, new TextDecoder().decode(src.data));
-    } else {
-      compiler.mapShadow(`/${src.path}`, src.data);
-    }
-  }
+	for (const src of req.sources) {
+		if (/\.typ$/i.test(src.path)) {
+			compiler.addSource(`/${src.path}`, new TextDecoder().decode(src.data));
+		} else {
+			compiler.mapShadow(`/${src.path}`, src.data);
+		}
+	}
 
-  // Note: typst.ts 0.6 does not expose package-fetch lifecycle events.
-  // The `fetching-packages` stage in the protocol is reserved for future use
-  // and is currently never emitted here.
-  post({ kind: "progress", payload: { stage: "compiling" } });
-  const res = await compiler.compile({
-    format: "pdf",
-    mainFilePath: `/${req.mainPath}`,
-    diagnostics: "full",
-  });
+	// Note: typst.ts 0.6 does not expose package-fetch lifecycle events.
+	// The `fetching-packages` stage in the protocol is reserved for future use
+	// and is currently never emitted here.
+	post({ kind: "progress", payload: { stage: "compiling" } });
+	const res = await compiler.compile({
+		format: "pdf",
+		mainFilePath: `/${req.mainPath}`,
+		diagnostics: "full",
+	});
 
-  if (res.result && res.result.length > 0) {
-    return { ok: true, pdf: res.result };
-  }
-  const diagnostics = (res.diagnostics ?? []).map(parseDiagnostic);
-  return { ok: false, diagnostics };
+	if (res.result && res.result.length > 0) {
+		return { ok: true, pdf: res.result };
+	}
+	const diagnostics = (res.diagnostics ?? []).map(parseDiagnostic);
+	return { ok: false, diagnostics };
 }
 
 self.addEventListener("message", async (ev: MessageEvent<WorkerInbound>) => {
-  if (ev.data.kind !== "compile") return;
-  try {
-    const result = await compile(ev.data.req);
-    post({ kind: "result", payload: result });
-  } catch (err) {
-    post({ kind: "fatal", message: err instanceof Error ? err.message : String(err) });
-  }
+	if (ev.data.kind !== "compile") return;
+	try {
+		const result = await compile(ev.data.req);
+		post({ kind: "result", payload: result });
+	} catch (err) {
+		post({
+			kind: "fatal",
+			message: err instanceof Error ? err.message : String(err),
+		});
+	}
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -203,6 +203,7 @@ export default defineConfig({
 			workbox: {
 				maximumFileSizeToCacheInBytes: 6 * 1024 * 1024,
 				globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2,wasm,mjs}"],
+				globIgnores: ["**/typst_ts_web_compiler_bg-*.wasm"],
 				navigateFallback: "/index.html",
 				cleanupOutdatedCaches: true,
 				clientsClaim: false,
@@ -213,6 +214,9 @@ export default defineConfig({
 	],
 	optimizeDeps: {
 		include: ["@myriaddreamin/typst.ts"],
+	},
+	worker: {
+		format: "es",
 	},
 	test: {
 		globals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -211,6 +211,9 @@ export default defineConfig({
 			devOptions: { enabled: false },
 		}),
 	],
+	optimizeDeps: {
+		include: ["@myriaddreamin/typst.ts"],
+	},
 	test: {
 		globals: true,
 		setupFiles: ["./src/test-setup.ts"],


### PR DESCRIPTION
## Summary

issue #12 の実装。`.typ` ファイルをブラウザ内で PDF にコンパイルし、既存の PDF プレゼンパイプラインに合流させる。

- typst.ts (WASM) を Web Worker 上で実行、メイン UI をブロックしない
- 公式パッケージレジストリ (`packages.typst.org`) から自動 fetch、touying / polylux 等の外部スライドフレームワークがそのまま動作
- D&D 経路は `webkitGetAsEntry` でフォルダごと再帰展開、サブディレクトリ込みプロジェクトに対応 (ピッカー経由はフラットのみ)
- 構文エラー時は HeroSection 直下に診断リスト (`file:line:col — message`) を展開
- Recent files に Typst ソースを保存、再オープンで毎回再コンパイル → FSA mode で外部エディタとの相互運用が成立
- 動的 import / Vite チャンク分割により、`.typ` を開かないユーザーには 21 MB WASM を一切ダウンロードさせない (PWA precache からも除外)

設計とプランは `docs/superpowers/specs/2026-05-03-typst-input-design.md` および `docs/superpowers/plans/2026-05-03-typst-input.md` (main に既存)。

## アーキテクチャ

```
[D&D / file input / FSA picker]
            │
   index.tsx#handleFiles
            │
  ┌─────────┴──────────┐
  │ .typ を含む?         │── No ──▶ 既存 PDF フロー
  └─────────┬──────────┘
            │ Yes
            ▼
  compileTypst (動的 import → Web Worker)
    1. WASM 読込
    2. パッケージ取得 (packages.typst.org)
    3. コンパイル → PDF Uint8Array  or  diagnostics[]
            │
       成功: synthetic File("compiled.pdf", "application/pdf")
       失敗: <TypstDiagnosticList items={...} /> を status に表示
            │
            ▼
  proceedWithPdf (recent 保存 / navigate / window.open)
```

## 主な変更ファイル

| 新規 | 役割 |
|---|---|
| `src/lib/typst.ts` | `compileTypst({ sources, mainPath }, { onProgress })` 公開 API + Worker クライアント |
| `src/lib/typst-source-detect.ts` | `containsTypst` / `pickMainTypst` / `filesToTypstSources` / `entriesToTypstSources` |
| `src/workers/typst-worker.ts` | typst.ts (WASM) を呼ぶ Worker、診断パース、進捗 postMessage |
| `src/components/TypstDiagnosticList.tsx` | severity アイコン付き診断リスト |

| 改修 | 内容 |
|---|---|
| `src/routes/$locale/(main)/index.tsx` | `handleFiles` の Typst 分岐、`proceedWithPdf` を抽出して PDF 経路と共有、Typst 用 recent 保存 + 再オープン再コンパイル |
| `src/routes/$locale/(main)/-index/HeroSection.tsx` | `.typ` を accept に追加、D&D の `webkitGetAsEntry` 再帰展開、`status: ReactNode` 受領 |
| `src/lib/recent-store.ts` | `RecentFile` を `kind: "pdf" \| "typst"` の判別共用体へ。読み出し時 `kind` 未設定 → `"pdf"` で互換維持 |
| `vite.config.ts` | `worker.format = "es"` (module Worker サポート) + `globIgnores` で 21 MB WASM を PWA precache から除外 |

## テスト

- `typst-source-detect.test.ts` (8 ケース): containsTypst / pickMainTypst の主ファイル判定ルール / filesToTypstSources / D&D エントリ再帰展開
- `typst.test.ts` (3 ケース): 最小 .typ → PDF 生成 (`%PDF-` 確認) / 構文エラーで診断 / 進捗ステージ順序
- `TypstDiagnosticList.test.tsx` (1 ケース): 行レンダリング検証
- 既存全テスト 89/89 PASS、Chromium で全 92 PASS

`index.tsx` の Typst 分岐の結合テストは見送り (現コードベースは UI クリックテスト = 1 件のみで、ロジックはユニット網羅 + 手動 smoke の方針のため)。

## ビルド / バンドル

- `pnpm tsc -b` ✅
- `pnpm build` ✅
- 初回バンドル `main-*.js` (745 KB) に typst.ts コードゼロ
- `typst-worker-*.js` (37 KB) と `typst_ts_web_compiler_bg-*.wasm` (21 MB) は分離チャンク、`.typ` を開いた時のみフェッチ
- PWA precache manifest からは WASM を除外 (`globIgnores`)

## Test plan

- [ ] `pnpm dev` で http://localhost:6123 を開く
- [ ] 最小 `.typ` (`= Hello\n\nWorld\n`) を D&D → presenter 起動
- [ ] touying サンプル (`#import \"@preview/touying:0.5.5\": *`) を D&D → パッケージ取得 → presenter 起動
- [ ] 構文エラー .typ (`#let x = (\n`) を D&D → HeroSection 下に診断リスト表示
- [ ] フォルダ D&D (`main.typ` + `logo.png`) → 画像が埋め込まれた PDF 表示
- [ ] 「最近開いたファイル」から Typst エントリをクリック → 再コンパイル → 再 presenter 起動
- [ ] `pnpm test` を TTY 経由で実行し chromium + firefox 両方で全テスト PASS
- [ ] `pnpm build` で WASM が 21 MB の独立アセットとして出力され、main bundle に typst.ts シンボルが含まれないことを確認

## Closes

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)